### PR TITLE
lib: add testBit impl.

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -778,6 +778,24 @@ BN.prototype.shrn = function shrn(bits) {
   return this.clone().ishrn(bits);
 };
 
+// Test if n bit is set
+BN.prototype.testn = function testn(bit) {
+  assert(typeof bit === 'number' && bit >= 0);
+  var r = bit % 26;
+  var s = (bit - r) / 26;
+  var q = 1 << r;
+
+  // Fast case: bit is much higher than all existing words
+  if (this.length <= s) {
+    return false;
+  }
+
+  // Check bit and return
+  var w = this.words[s];
+
+  return !!(w & q);
+};
+
 // Return only lowers bits of number (in-place)
 BN.prototype.imaskn = function imaskn(bits) {
   assert(typeof bits === 'number' && bits >= 0);

--- a/test/bn-test.js
+++ b/test/bn-test.js
@@ -304,4 +304,34 @@ describe('BN', function() {
     assert.equal(new BN('123456789', 16).imaskn(16).toString(16), '6789');
     assert.equal(new BN('123456789', 16).imaskn(28).toString(16), '3456789');
   });
+
+  it('should support testn', function() {
+    [
+      'ff',
+      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+    ].forEach(function(hex) {
+      var bn = new BN(hex, 16)
+      var bl = bn.bitLength()
+
+      for (var i = 0; i < bl; ++i) {
+        assert.equal(bn.testn(i), true);
+      }
+
+      // test off the end
+      assert.equal(bn.testn(bl), false);
+    })
+
+    var xbits = [
+      '01111001010111001001000100011101110100111011000110001110010111011001010',
+      '01110000000010110001111010101111100111110010001111000001001011010100111',
+      '01000101001100010001101001011110100001001111100110001110010111'
+    ].join('')
+
+    var x = new BN(
+      '23478905234580795234378912401239784125643978256123048348957342'
+    )
+    for (var i = 0; i < x.bitLength(); ++i) {
+      assert.equal(x.testn(i), (xbits.charAt(i) === '1'), 'Failed @ bit ' + i)
+    }
+  });
 });


### PR DESCRIPTION
This pull request adds a `testBit` implementation and appropriate tests.

I'm still getting my head around how the internal state is stored, so this may not be the most correct/efficient way.  But, it passes all the tests I've thrown at it.

Feel free to abuse, and I'm happy to make any changes required. 
