### PR TITLE
addn failing test

### DIFF
--- a/test/bn-test.js
+++ b/test/bn-test.js
@@ -65,6 +65,18 @@ describe('BN', function() {
     assert.equal(r.toString(16), 'ac79bd9b79be7a277bde');
   });
 
+  describe('iaddn', function() {
+    it('should allow a sign change', function() {
+      var a = new BN(-100)
+      assert.equal(a.sign, true)
+
+      a.iaddn(200)
+
+      assert.equal(a.sign, false)
+      assert.equal(a.toString(), '100')
+    })
+  })
+
   it('should subtract numbers', function() {
     assert.equal(new BN(14).sub(new BN(26)).toString(16), '-c');
     assert.equal(new BN(26).sub(new BN(14)).toString(16), 'c');
@@ -104,6 +116,26 @@ describe('BN', function() {
     var b = new BN('1000000000000', 16);
     assert.equal(b.isub(a).toString(16), 'fffffffedcbb');
   });
+
+  describe('isubn', function() {
+    it('should work for positive numbers', function() {
+      var a = new BN(-100)
+      assert.equal(a.sign, true)
+
+      a.isubn(200)
+      assert.equal(a.sign, true)
+      assert.equal(a.toString(), '-300')
+    })
+
+    it('should not allow a sign change', function() {
+      var a = new BN(-100)
+      assert.equal(a.sign, true)
+
+      assert.throws(function() {
+        a.isubn(-200)
+      }, /Sign change is not supported in isubn/)
+    })
+  })
 
   it('should mul numbers', function() {
     assert.equal(new BN(0x1001).mul(new BN(0x1234)).toString(16),


### PR DESCRIPTION
Currently `iaddn` and `isubn` do not throw when a sign change occurs; and `isubn` throws in a case it shouldn't.
This can lead to highly erroneous behaviour such as `-100 + 200 == -300`.

This pull request adds a failing test to indicate this support does not exist (yet), and should serve as a warning to others until then.
