### PR TITLE
bn: `.sign` either `0` or `1`, other improvements

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -29,7 +29,7 @@ function BN(number, base, endian) {
     return number;
   }
 
-  this.sign = false;
+  this.sign = 0;
   this.words = null;
   this.length = 0;
 
@@ -87,7 +87,7 @@ BN.prototype._init = function init(number, base, endian) {
     this._parseBase(number, base, start);
 
   if (number[0] === '-')
-    this.sign = true;
+    this.sign = 1;
 
   this.strip();
 
@@ -99,7 +99,7 @@ BN.prototype._init = function init(number, base, endian) {
 
 BN.prototype._initNumber = function _initNumber(number, base, endian) {
   if (number < 0) {
-    this.sign = true;
+    this.sign = 1;
     number = -number;
   }
   if (number < 0x4000000) {
@@ -307,7 +307,7 @@ BN.prototype.strip = function strip() {
 BN.prototype._normSign = function _normSign() {
   // -0 = 0
   if (this.length === 1 && this.words[0] === 0)
-    this.sign = false;
+    this.sign = 0;
   return this;
 };
 
@@ -417,7 +417,7 @@ BN.prototype.toString = function toString(base, padding) {
       out = carry.toString(16) + out;
     while (out.length % padding !== 0)
       out = '0' + out;
-    if (this.sign)
+    if (this.sign !== 0)
       out = '-' + out;
     return out;
   } else if (base === (base | 0) && base >= 2 && base <= 36) {
@@ -427,7 +427,7 @@ BN.prototype.toString = function toString(base, padding) {
     var groupBase = groupBases[base];
     var out = '';
     var c = this.clone();
-    c.sign = false;
+    c.sign = 0;
     while (c.cmpn(0) !== 0) {
       var r = c.modn(groupBase).toString(base);
       c = c.idivn(groupBase);
@@ -441,7 +441,7 @@ BN.prototype.toString = function toString(base, padding) {
       out = '0' + out;
     while (out.length % padding !== 0)
       out = '0' + out;
-    if (this.sign)
+    if (this.sign !== 0)
       out = '-' + out;
     return out;
   } else {
@@ -593,10 +593,14 @@ BN.prototype.neg = function neg() {
     return this.clone();
 
   var r = this.clone();
-  r.sign = !this.sign;
+  r.sign = this.sign ^ 1;
   return r;
 };
 
+BN.prototype.ineg = function ineg() {
+  this.sign ^= 1;
+  return this;
+};
 
 // Or `num` with `this` in-place
 BN.prototype.iuor = function iuor(num) {
@@ -610,7 +614,7 @@ BN.prototype.iuor = function iuor(num) {
 };
 
 BN.prototype.ior = function ior(num) {
-  assert(!this.sign && !num.sign);
+  assert((this.sign | num.sign) === 0);
   return this.iuor(num);
 };
 
@@ -649,7 +653,7 @@ BN.prototype.iuand = function iuand(num) {
 };
 
 BN.prototype.iand = function iand(num) {
-  assert(!this.sign && !num.sign);
+  assert((this.sign | num.sign) === 0);
   return this.iuand(num);
 };
 
@@ -696,7 +700,7 @@ BN.prototype.iuxor = function iuxor(num) {
 };
 
 BN.prototype.ixor = function ixor(num) {
-  assert(!this.sign && !num.sign);
+  assert((this.sign | num.sign) === 0);
   return this.iuxor(num);
 };
 
@@ -739,17 +743,17 @@ BN.prototype.setn = function setn(bit, val) {
 // Add `num` to `this` in-place
 BN.prototype.iadd = function iadd(num) {
   // negative + positive
-  if (this.sign && !num.sign) {
-    this.sign = false;
+  if (this.sign !== 0 && num.sign === 0) {
+    this.sign = 0;
     var r = this.isub(num);
-    this.sign = !this.sign;
+    this.sign ^= 1;
     return this._normSign();
 
   // positive + negative
-  } else if (!this.sign && num.sign) {
-    num.sign = false;
+  } else if (this.sign === 0 && num.sign === 1) {
+    num.sign = 0;
     var r = this.isub(num);
-    num.sign = true;
+    num.sign = 1;
     return r._normSign();
   }
 
@@ -766,12 +770,12 @@ BN.prototype.iadd = function iadd(num) {
 
   var carry = 0;
   for (var i = 0; i < b.length; i++) {
-    var r = a.words[i] + b.words[i] + carry;
+    var r = (a.words[i] | 0) + (b.words[i] | 0) + carry;
     this.words[i] = r & 0x3ffffff;
     carry = r >>> 26;
   }
   for (; carry !== 0 && i < a.length; i++) {
-    var r = a.words[i] + carry;
+    var r = (a.words[i] | 0) + carry;
     this.words[i] = r & 0x3ffffff;
     carry = r >>> 26;
   }
@@ -791,15 +795,15 @@ BN.prototype.iadd = function iadd(num) {
 
 // Add `num` to `this`
 BN.prototype.add = function add(num) {
-  if (num.sign && !this.sign) {
-    num.sign = false;
+  if (num.sign !== 0 && this.sign === 0) {
+    num.sign = 0;
     var res = this.sub(num);
-    num.sign = true;
+    num.sign ^= 1;
     return res;
-  } else if (!num.sign && this.sign) {
-    this.sign = false;
+  } else if (num.sign === 0 && this.sign !== 0) {
+    this.sign = 0;
     var res = num.sub(this);
-    this.sign = true;
+    this.sign = 1;
     return res;
   }
 
@@ -812,17 +816,17 @@ BN.prototype.add = function add(num) {
 // Subtract `num` from `this` in-place
 BN.prototype.isub = function isub(num) {
   // this - (-num) = this + num
-  if (num.sign) {
-    num.sign = false;
+  if (num.sign !== 0) {
+    num.sign = 0;
     var r = this.iadd(num);
-    num.sign = true;
+    num.sign = 1;
     return r._normSign();
 
   // -this - num = -(this + num)
-  } else if (this.sign) {
-    this.sign = false;
+  } else if (this.sign !== 0) {
+    this.sign = 0;
     this.iadd(num);
-    this.sign = true;
+    this.sign = 1;
     return this._normSign();
   }
 
@@ -831,7 +835,7 @@ BN.prototype.isub = function isub(num) {
 
   // Optimization - zeroify
   if (cmp === 0) {
-    this.sign = false;
+    this.sign = 0;
     this.length = 1;
     this.words[0] = 0;
     return this;
@@ -850,12 +854,12 @@ BN.prototype.isub = function isub(num) {
 
   var carry = 0;
   for (var i = 0; i < b.length; i++) {
-    var r = a.words[i] - b.words[i] + carry;
+    var r = (a.words[i] | 0) - (b.words[i] | 0) + carry;
     carry = r >> 26;
     this.words[i] = r & 0x3ffffff;
   }
   for (; carry !== 0 && i < a.length; i++) {
-    var r = a.words[i] + carry;
+    var r = (a.words[i] | 0) + carry;
     carry = r >> 26;
     this.words[i] = r & 0x3ffffff;
   }
@@ -867,7 +871,7 @@ BN.prototype.isub = function isub(num) {
   this.length = Math.max(this.length, i);
 
   if (a !== this)
-    this.sign = true;
+    this.sign = 1;
 
   return this.strip();
 };
@@ -915,20 +919,30 @@ function _genCombMulTo(alen, blen) {
 }
 */
 
-BN.prototype._smallMulTo = function _smallMulTo(num, out) {
-  out.sign = num.sign !== this.sign;
-  out.length = this.length + num.length;
+function smallMulTo(self, num, out) {
+  out.sign = num.sign ^ self.sign;
+  var len = (self.length + num.length) | 0;
+  out.length = len;
+  len = (len - 1) | 0;
 
-  var carry = 0;
-  for (var k = 0; k < out.length - 1; k++) {
+  // Peel one iteration (compiler can't do it, because of code complexity)
+  var a = self.words[0] | 0;
+  var b = num.words[0] | 0;
+  var r = a * b;
+
+  var lo = r & 0x3ffffff;
+  var carry = (r / 0x4000000) | 0;
+  out.words[0] = lo;
+
+  for (var k = 1; k < len; k++) {
     // Sum all words with the same `i + j = k` and accumulate `ncarry`,
     // note that ncarry could be >= 0x3ffffff
     var ncarry = carry >>> 26;
     var rword = carry & 0x3ffffff;
     var maxJ = Math.min(k, num.length - 1);
-    for (var j = Math.max(0, k - this.length + 1); j <= maxJ; j++) {
-      var i = k - j;
-      var a = this.words[i] | 0;
+    for (var j = Math.max(0, k - self.length + 1); j <= maxJ; j++) {
+      var i = (k - j) | 0;
+      var a = self.words[i] | 0;
       var b = num.words[j] | 0;
       var r = a * b;
 
@@ -938,21 +952,21 @@ BN.prototype._smallMulTo = function _smallMulTo(num, out) {
       rword = lo & 0x3ffffff;
       ncarry = (ncarry + (lo >>> 26)) | 0;
     }
-    out.words[k] = rword;
-    carry = ncarry;
+    out.words[k] = rword | 0;
+    carry = ncarry | 0;
   }
   if (carry !== 0) {
-    out.words[k] = carry;
+    out.words[k] = carry | 0;
   } else {
     out.length--;
   }
 
   return out.strip();
-};
+}
 
-BN.prototype._bigMulTo = function _bigMulTo(num, out) {
-  out.sign = num.sign !== this.sign;
-  out.length = this.length + num.length;
+function bigMulTo(self, num, out) {
+  out.sign = num.sign ^ self.sign;
+  out.length = self.length + num.length;
 
   var carry = 0;
   var hncarry = 0;
@@ -963,9 +977,9 @@ BN.prototype._bigMulTo = function _bigMulTo(num, out) {
     hncarry = 0;
     var rword = carry & 0x3ffffff;
     var maxJ = Math.min(k, num.length - 1);
-    for (var j = Math.max(0, k - this.length + 1); j <= maxJ; j++) {
+    for (var j = Math.max(0, k - self.length + 1); j <= maxJ; j++) {
       var i = k - j;
-      var a = this.words[i] | 0;
+      var a = self.words[i] | 0;
       var b = num.words[j] | 0;
       var r = a * b;
 
@@ -989,14 +1003,14 @@ BN.prototype._bigMulTo = function _bigMulTo(num, out) {
   }
 
   return out.strip();
-};
+}
 
 BN.prototype.mulTo = function mulTo(num, out) {
   var res;
   if (this.length + num.length < 63)
-    res = this._smallMulTo(num, out);
+    res = smallMulTo(this, num, out);
   else
-    res = this._bigMulTo(num, out);
+    res = bigMulTo(this, num, out);
   return res;
 };
 
@@ -1018,7 +1032,7 @@ BN.prototype.imul = function imul(num) {
   var tlen = this.length;
   var nlen = num.length;
 
-  this.sign = num.sign !== this.sign;
+  this.sign = num.sign ^ this.sign;
   this.length = this.length + num.length;
   this.words[this.length - 1] = 0;
 
@@ -1030,8 +1044,8 @@ BN.prototype.imul = function imul(num) {
     var maxJ = Math.min(k, nlen - 1);
     for (var j = Math.max(0, k - tlen + 1); j <= maxJ; j++) {
       var i = k - j;
-      var a = this.words[i];
-      var b = num.words[j];
+      var a = this.words[i] | 0;
+      var b = num.words[j] | 0;
       var r = a * b;
 
       var lo = r & 0x3ffffff;
@@ -1048,7 +1062,7 @@ BN.prototype.imul = function imul(num) {
   // Propagate overflows
   var carry = 0;
   for (var i = 1; i < this.length; i++) {
-    var w = this.words[i] + carry;
+    var w = (this.words[i] | 0) + carry;
     this.words[i] = w & 0x3ffffff;
     carry = w >>> 26;
   }
@@ -1062,7 +1076,7 @@ BN.prototype.imuln = function imuln(num) {
   // Carry
   var carry = 0;
   for (var i = 0; i < this.length; i++) {
-    var w = this.words[i] * num;
+    var w = (this.words[i] | 0) * num;
     var lo = (w & 0x3ffffff) + (carry & 0x3ffffff);
     carry >>= 26;
     carry += (w / 0x4000000) | 0;
@@ -1127,7 +1141,7 @@ BN.prototype.iushln = function iushln(bits) {
     var carry = 0;
     for (var i = 0; i < this.length; i++) {
       var newCarry = this.words[i] & carryMask;
-      var c = (this.words[i] - newCarry) << r;
+      var c = ((this.words[i] | 0) - newCarry) << r;
       this.words[i] = c | carry;
       carry = newCarry >>> (26 - r);
     }
@@ -1150,7 +1164,7 @@ BN.prototype.iushln = function iushln(bits) {
 
 BN.prototype.ishln = function ishln(bits) {
   // TODO(indutny): implement me
-  assert(!this.sign);
+  assert(this.sign === 0);
   return this.iushln(bits);
 };
 
@@ -1193,7 +1207,7 @@ BN.prototype.iushrn = function iushrn(bits, hint, extended) {
 
   var carry = 0;
   for (var i = this.length - 1; i >= 0 && (carry !== 0 || i >= h); i--) {
-    var word = this.words[i];
+    var word = this.words[i] | 0;
     this.words[i] = (carry << (26 - r)) | (word >>> r);
     carry = word & mask;
   }
@@ -1214,7 +1228,7 @@ BN.prototype.iushrn = function iushrn(bits, hint, extended) {
 
 BN.prototype.ishrn = function ishrn(bits, hint, extended) {
   // TODO(indutny): implement me
-  assert(!this.sign);
+  assert(this.sign === 0);
   return this.iushrn(bits, hint, extended);
 };
 
@@ -1260,7 +1274,7 @@ BN.prototype.imaskn = function imaskn(bits) {
   var r = bits % 26;
   var s = (bits - r) / 26;
 
-  assert(!this.sign, 'imaskn works only with positive numbers');
+  assert(this.sign === 0, 'imaskn works only with positive numbers');
 
   if (r !== 0)
     s++;
@@ -1286,16 +1300,16 @@ BN.prototype.iaddn = function iaddn(num) {
     return this.isubn(-num);
 
   // Possible sign change
-  if (this.sign) {
-    if (this.length === 1 && this.words[0] < num) {
-      this.words[0] = num - this.words[0];
-      this.sign = false;
+  if (this.sign !== 0) {
+    if (this.length === 1 && (this.words[0] | 0) < num) {
+      this.words[0] = num - (this.words[0] | 0);
+      this.sign = 0;
       return this;
     }
 
-    this.sign = false;
+    this.sign = 0;
     this.isubn(num);
-    this.sign = true;
+    this.sign = 1;
     return this;
   }
 
@@ -1325,10 +1339,10 @@ BN.prototype.isubn = function isubn(num) {
   if (num < 0)
     return this.iaddn(-num);
 
-  if (this.sign) {
-    this.sign = false;
+  if (this.sign !== 0) {
+    this.sign = 0;
     this.iaddn(num);
-    this.sign = true;
+    this.sign = 1;
     return this;
   }
 
@@ -1352,7 +1366,7 @@ BN.prototype.subn = function subn(num) {
 };
 
 BN.prototype.iabs = function iabs() {
-  this.sign = false;
+  this.sign = 0;
 
   return this;
 };
@@ -1381,14 +1395,14 @@ BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
 
   var carry = 0;
   for (var i = 0; i < num.length; i++) {
-    var w = this.words[i + shift] + carry;
-    var right = num.words[i] * mul;
+    var w = (this.words[i + shift] | 0) + carry;
+    var right = (num.words[i] | 0) * mul;
     w -= right & 0x3ffffff;
     carry = (w >> 26) - ((right / 0x4000000) | 0);
     this.words[i + shift] = w & 0x3ffffff;
   }
   for (; i < this.length - shift; i++) {
-    var w = this.words[i + shift] + carry;
+    var w = (this.words[i + shift] | 0) + carry;
     carry = w >> 26;
     this.words[i + shift] = w & 0x3ffffff;
   }
@@ -1400,11 +1414,11 @@ BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
   assert(carry === -1);
   carry = 0;
   for (var i = 0; i < this.length; i++) {
-    var w = -this.words[i] + carry;
+    var w = -(this.words[i] | 0) + carry;
     carry = w >> 26;
     this.words[i] = w & 0x3ffffff;
   }
-  this.sign = true;
+  this.sign = 1;
 
   return this.strip();
 };
@@ -1416,13 +1430,13 @@ BN.prototype._wordDiv = function _wordDiv(num, mode) {
   var b = num;
 
   // Normalize
-  var bhi = b.words[b.length - 1];
+  var bhi = b.words[b.length - 1] | 0;
   var bhiBits = this._countBits(bhi);
   shift = 26 - bhiBits;
   if (shift !== 0) {
     b = b.ushln(shift);
     a.iushln(shift);
-    bhi = b.words[b.length - 1];
+    bhi = b.words[b.length - 1] | 0;
   }
 
   // Initialize quotient
@@ -1438,26 +1452,27 @@ BN.prototype._wordDiv = function _wordDiv(num, mode) {
   }
 
   var diff = a.clone()._ishlnsubmul(b, 1, m);
-  if (!diff.sign) {
+  if (diff.sign === 0) {
     a = diff;
     if (q)
       q.words[m] = 1;
   }
 
   for (var j = m - 1; j >= 0; j--) {
-    var qj = a.words[b.length + j] * 0x4000000 + a.words[b.length + j - 1];
+    var qj = (a.words[b.length + j] | 0) * 0x4000000 +
+             (a.words[b.length + j - 1] | 0);
 
     // NOTE: (qj / bhi) is (0x3ffffff * 0x4000000 + 0x3ffffff) / 0x2000000 max
     // (0x7ffffff)
     qj = Math.min((qj / bhi) | 0, 0x3ffffff);
 
     a._ishlnsubmul(b, qj, j);
-    while (a.sign) {
+    while (a.sign === 1) {
       qj--;
-      a.sign = false;
+      a.sign = 0;
       a._ishlnsubmul(b, 1, j);
       if (a.cmpn(0) !== 0)
-        a.sign = !a.sign;
+        a.sign ^= 1;
     }
     if (q)
       q.words[j] = qj;
@@ -1475,7 +1490,7 @@ BN.prototype._wordDiv = function _wordDiv(num, mode) {
 BN.prototype.divmod = function divmod(num, mode, positive) {
   assert(num.cmpn(0) !== 0);
 
-  if (this.sign && !num.sign) {
+  if (this.sign !== 0 && num.sign === 0) {
     var res = this.neg().divmod(num, mode);
     var div;
     var mod;
@@ -1490,13 +1505,13 @@ BN.prototype.divmod = function divmod(num, mode, positive) {
       div: div,
       mod: mod
     };
-  } else if (!this.sign && num.sign) {
+  } else if (this.sign === 0 && num.sign !== 0) {
     var res = this.divmod(num.neg(), mode);
     var div;
     if (mode !== 'mod')
       div = res.div.neg();
     return { div: div, mod: res.mod };
-  } else if (this.sign && num.sign) {
+  } else if ((this.sign & num.sign) !== 0) {
     var res = this.neg().divmod(num.neg(), mode);
     var mod;
     if (mode !== 'div') {
@@ -1553,7 +1568,7 @@ BN.prototype.divRound = function divRound(num) {
   if (dm.mod.cmpn(0) === 0)
     return dm.div;
 
-  var mod = dm.div.sign ? dm.mod.isub(num) : dm.mod;
+  var mod = dm.div.sign !== 0 ? dm.mod.isub(num) : dm.mod;
 
   var half = num.ushrn(1);
   var r2 = num.andln(1);
@@ -1564,7 +1579,7 @@ BN.prototype.divRound = function divRound(num) {
     return dm.div;
 
   // Round up
-  return dm.div.sign ? dm.div.isubn(1) : dm.div.iaddn(1);
+  return dm.div.sign !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
 };
 
 BN.prototype.modn = function modn(num) {
@@ -1573,7 +1588,7 @@ BN.prototype.modn = function modn(num) {
 
   var acc = 0;
   for (var i = this.length - 1; i >= 0; i--)
-    acc = (p * acc + this.words[i]) % num;
+    acc = (p * acc + (this.words[i] | 0)) % num;
 
   return acc;
 };
@@ -1584,7 +1599,7 @@ BN.prototype.idivn = function idivn(num) {
 
   var carry = 0;
   for (var i = this.length - 1; i >= 0; i--) {
-    var w = this.words[i] + carry * 0x4000000;
+    var w = (this.words[i] | 0) + carry * 0x4000000;
     this.words[i] = (w / num) | 0;
     carry = w % num;
   }
@@ -1597,13 +1612,13 @@ BN.prototype.divn = function divn(num) {
 };
 
 BN.prototype.egcd = function egcd(p) {
-  assert(!p.sign);
+  assert(p.sign === 0);
   assert(p.cmpn(0) !== 0);
 
   var x = this;
   var y = p.clone();
 
-  if (x.sign)
+  if (x.sign !== 0)
     x = x.umod(p);
   else
     x = x.clone();
@@ -1672,13 +1687,13 @@ BN.prototype.egcd = function egcd(p) {
 // above, designated to invert members of the
 // _prime_ fields F(p) at a maximal speed
 BN.prototype._invmp = function _invmp(p) {
-  assert(!p.sign);
+  assert(p.sign === 0);
   assert(p.cmpn(0) !== 0);
 
   var a = this;
   var b = p.clone();
 
-  if (a.sign)
+  if (a.sign !== 0)
     a = a.umod(p);
   else
     a = a.clone();
@@ -1732,8 +1747,8 @@ BN.prototype.gcd = function gcd(num) {
 
   var a = this.clone();
   var b = num.clone();
-  a.sign = false;
-  b.sign = false;
+  a.sign = 0;
+  b.sign = 0;
 
   // Remove common factor of two
   for (var shift = 0; a.isEven() && b.isEven(); shift++) {
@@ -1800,7 +1815,7 @@ BN.prototype.bincn = function bincn(bit) {
   // Add bit and propagate, if needed
   var carry = q;
   for (var i = s; carry !== 0 && i < this.length; i++) {
-    var w = this.words[i];
+    var w = this.words[i] | 0;
     w += carry;
     carry = w >>> 26;
     w &= 0x3ffffff;
@@ -1818,9 +1833,9 @@ BN.prototype.cmpn = function cmpn(num) {
   if (sign)
     num = -num;
 
-  if (this.sign && !sign)
+  if (this.sign !== 0 && !sign)
     return -1;
-  else if (!this.sign && sign)
+  else if (this.sign === 0 && sign)
     return 1;
 
   num &= 0x3ffffff;
@@ -1830,10 +1845,10 @@ BN.prototype.cmpn = function cmpn(num) {
   if (this.length > 1) {
     res = 1;
   } else {
-    var w = this.words[0];
+    var w = this.words[0] | 0;
     res = w === num ? 0 : w < num ? -1 : 1;
   }
-  if (this.sign)
+  if (this.sign !== 0)
     res = -res;
   return res;
 };
@@ -1843,13 +1858,13 @@ BN.prototype.cmpn = function cmpn(num) {
 // 0 - if `this` == `num`
 // -1 - if `this` < `num`
 BN.prototype.cmp = function cmp(num) {
-  if (this.sign && !num.sign)
+  if (this.sign !== 0 && num.sign === 0)
     return -1;
-  else if (!this.sign && num.sign)
+  else if (this.sign === 0 && num.sign !== 0)
     return 1;
 
   var res = this.ucmp(num);
-  if (this.sign)
+  if (this.sign !== 0)
     return -res;
   else
     return res;
@@ -1865,8 +1880,8 @@ BN.prototype.ucmp = function ucmp(num) {
 
   var res = 0;
   for (var i = this.length - 1; i >= 0; i--) {
-    var a = this.words[i];
-    var b = num.words[i];
+    var a = this.words[i] | 0;
+    var b = num.words[i] | 0;
 
     if (a === b)
       continue;
@@ -1889,7 +1904,7 @@ BN.red = function red(num) {
 
 BN.prototype.toRed = function toRed(ctx) {
   assert(!this.red, 'Already a number in reduction context');
-  assert(!this.sign, 'red works only with positives');
+  assert(this.sign === 0, 'red works only with positives');
   return ctx.convertTo(this)._forceRed(ctx);
 };
 
@@ -2070,7 +2085,7 @@ K256.prototype.split = function split(input, output) {
   output.words[output.length++] = prev & mask;
 
   for (var i = 10; i < input.length; i++) {
-    var next = input.words[i];
+    var next = input.words[i] | 0;
     input.words[i - 10] = ((next & mask) << 4) | (prev >>> 22);
     prev = next;
   }
@@ -2088,7 +2103,7 @@ K256.prototype.imulK = function imulK(num) {
   var hi;
   var lo = 0;
   for (var i = 0; i < num.length; i++) {
-    var w = num.words[i];
+    var w = num.words[i] | 0;
     hi = w * 0x40;
     lo += w * 0x3d1;
     hi += (lo / 0x4000000) | 0;
@@ -2137,7 +2152,7 @@ P25519.prototype.imulK = function imulK(num) {
   // K = 0x13
   var carry = 0;
   for (var i = 0; i < num.length; i++) {
-    var hi = num.words[i] * 0x13 + carry;
+    var hi = (num.words[i] | 0) * 0x13 + carry;
     var lo = hi & 0x3ffffff;
     hi >>>= 26;
 
@@ -2186,12 +2201,12 @@ function Red(m) {
 }
 
 Red.prototype._verify1 = function _verify1(a) {
-  assert(!a.sign, 'red works only with positives');
+  assert(a.sign === 0, 'red works only with positives');
   assert(a.red, 'red works only with red numbers');
 };
 
 Red.prototype._verify2 = function _verify2(a, b) {
-  assert(!a.sign && !b.sign, 'red works only with positives');
+  assert((a.sign | b.sign) === 0, 'red works only with positives');
   assert(a.red && a.red === b.red,
          'red works only with red numbers');
 };
@@ -2204,7 +2219,7 @@ Red.prototype.imod = function imod(a) {
 
 Red.prototype.neg = function neg(a) {
   var r = a.clone();
-  r.sign = !r.sign;
+  r.sign ^= 1;
   return r.iadd(this.m)._forceRed(this);
 };
 
@@ -2325,8 +2340,8 @@ Red.prototype.sqrt = function sqrt(a) {
 
 Red.prototype.invm = function invm(a) {
   var inv = a._invmp(this.m);
-  if (inv.sign) {
-    inv.sign = false;
+  if (inv.sign !== 0) {
+    inv.sign = 0;
     return this.imod(inv).redNeg();
   } else {
     return this.imod(inv);

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -29,7 +29,7 @@ function BN(number, base, endian) {
     return number;
   }
 
-  this.sign = 0;
+  this.negative = 0;
   this.words = null;
   this.length = 0;
 
@@ -87,7 +87,7 @@ BN.prototype._init = function init(number, base, endian) {
     this._parseBase(number, base, start);
 
   if (number[0] === '-')
-    this.sign = 1;
+    this.negative = 1;
 
   this.strip();
 
@@ -99,7 +99,7 @@ BN.prototype._init = function init(number, base, endian) {
 
 BN.prototype._initNumber = function _initNumber(number, base, endian) {
   if (number < 0) {
-    this.sign = 1;
+    this.negative = 1;
     number = -number;
   }
   if (number < 0x4000000) {
@@ -287,7 +287,7 @@ BN.prototype.copy = function copy(dest) {
   for (var i = 0; i < this.length; i++)
     dest.words[i] = this.words[i];
   dest.length = this.length;
-  dest.sign = this.sign;
+  dest.negative = this.negative;
   dest.red = this.red;
 };
 
@@ -307,7 +307,7 @@ BN.prototype.strip = function strip() {
 BN.prototype._normSign = function _normSign() {
   // -0 = 0
   if (this.length === 1 && this.words[0] === 0)
-    this.sign = 0;
+    this.negative = 0;
   return this;
 };
 
@@ -417,7 +417,7 @@ BN.prototype.toString = function toString(base, padding) {
       out = carry.toString(16) + out;
     while (out.length % padding !== 0)
       out = '0' + out;
-    if (this.sign !== 0)
+    if (this.negative !== 0)
       out = '-' + out;
     return out;
   } else if (base === (base | 0) && base >= 2 && base <= 36) {
@@ -427,7 +427,7 @@ BN.prototype.toString = function toString(base, padding) {
     var groupBase = groupBases[base];
     var out = '';
     var c = this.clone();
-    c.sign = 0;
+    c.negative = 0;
     while (c.cmpn(0) !== 0) {
       var r = c.modn(groupBase).toString(base);
       c = c.idivn(groupBase);
@@ -441,7 +441,7 @@ BN.prototype.toString = function toString(base, padding) {
       out = '0' + out;
     while (out.length % padding !== 0)
       out = '0' + out;
-    if (this.sign !== 0)
+    if (this.negative !== 0)
       out = '-' + out;
     return out;
   } else {
@@ -593,12 +593,12 @@ BN.prototype.neg = function neg() {
     return this.clone();
 
   var r = this.clone();
-  r.sign = this.sign ^ 1;
+  r.negative = this.negative ^ 1;
   return r;
 };
 
 BN.prototype.ineg = function ineg() {
-  this.sign ^= 1;
+  this.negative ^= 1;
   return this;
 };
 
@@ -614,7 +614,7 @@ BN.prototype.iuor = function iuor(num) {
 };
 
 BN.prototype.ior = function ior(num) {
-  assert((this.sign | num.sign) === 0);
+  assert((this.negative | num.negative) === 0);
   return this.iuor(num);
 };
 
@@ -653,7 +653,7 @@ BN.prototype.iuand = function iuand(num) {
 };
 
 BN.prototype.iand = function iand(num) {
-  assert((this.sign | num.sign) === 0);
+  assert((this.negative | num.negative) === 0);
   return this.iuand(num);
 };
 
@@ -700,7 +700,7 @@ BN.prototype.iuxor = function iuxor(num) {
 };
 
 BN.prototype.ixor = function ixor(num) {
-  assert((this.sign | num.sign) === 0);
+  assert((this.negative | num.negative) === 0);
   return this.iuxor(num);
 };
 
@@ -743,17 +743,17 @@ BN.prototype.setn = function setn(bit, val) {
 // Add `num` to `this` in-place
 BN.prototype.iadd = function iadd(num) {
   // negative + positive
-  if (this.sign !== 0 && num.sign === 0) {
-    this.sign = 0;
+  if (this.negative !== 0 && num.negative === 0) {
+    this.negative = 0;
     var r = this.isub(num);
-    this.sign ^= 1;
+    this.negative ^= 1;
     return this._normSign();
 
   // positive + negative
-  } else if (this.sign === 0 && num.sign === 1) {
-    num.sign = 0;
+  } else if (this.negative === 0 && num.negative !== 0) {
+    num.negative = 0;
     var r = this.isub(num);
-    num.sign = 1;
+    num.negative = 1;
     return r._normSign();
   }
 
@@ -795,15 +795,15 @@ BN.prototype.iadd = function iadd(num) {
 
 // Add `num` to `this`
 BN.prototype.add = function add(num) {
-  if (num.sign !== 0 && this.sign === 0) {
-    num.sign = 0;
+  if (num.negative !== 0 && this.negative === 0) {
+    num.negative = 0;
     var res = this.sub(num);
-    num.sign ^= 1;
+    num.negative ^= 1;
     return res;
-  } else if (num.sign === 0 && this.sign !== 0) {
-    this.sign = 0;
+  } else if (num.negative === 0 && this.negative !== 0) {
+    this.negative = 0;
     var res = num.sub(this);
-    this.sign = 1;
+    this.negative = 1;
     return res;
   }
 
@@ -816,17 +816,17 @@ BN.prototype.add = function add(num) {
 // Subtract `num` from `this` in-place
 BN.prototype.isub = function isub(num) {
   // this - (-num) = this + num
-  if (num.sign !== 0) {
-    num.sign = 0;
+  if (num.negative !== 0) {
+    num.negative = 0;
     var r = this.iadd(num);
-    num.sign = 1;
+    num.negative = 1;
     return r._normSign();
 
   // -this - num = -(this + num)
-  } else if (this.sign !== 0) {
-    this.sign = 0;
+  } else if (this.negative !== 0) {
+    this.negative = 0;
     this.iadd(num);
-    this.sign = 1;
+    this.negative = 1;
     return this._normSign();
   }
 
@@ -835,7 +835,7 @@ BN.prototype.isub = function isub(num) {
 
   // Optimization - zeroify
   if (cmp === 0) {
-    this.sign = 0;
+    this.negative = 0;
     this.length = 1;
     this.words[0] = 0;
     return this;
@@ -871,7 +871,7 @@ BN.prototype.isub = function isub(num) {
   this.length = Math.max(this.length, i);
 
   if (a !== this)
-    this.sign = 1;
+    this.negative = 1;
 
   return this.strip();
 };
@@ -920,7 +920,7 @@ function _genCombMulTo(alen, blen) {
 */
 
 function smallMulTo(self, num, out) {
-  out.sign = num.sign ^ self.sign;
+  out.negative = num.negative ^ self.negative;
   var len = (self.length + num.length) | 0;
   out.length = len;
   len = (len - 1) | 0;
@@ -965,7 +965,7 @@ function smallMulTo(self, num, out) {
 }
 
 function bigMulTo(self, num, out) {
-  out.sign = num.sign ^ self.sign;
+  out.negative = num.negative ^ self.negative;
   out.length = self.length + num.length;
 
   var carry = 0;
@@ -1032,7 +1032,7 @@ BN.prototype.imul = function imul(num) {
   var tlen = this.length;
   var nlen = num.length;
 
-  this.sign = num.sign ^ this.sign;
+  this.negative = num.negative ^ this.negative;
   this.length = this.length + num.length;
   this.words[this.length - 1] = 0;
 
@@ -1164,7 +1164,7 @@ BN.prototype.iushln = function iushln(bits) {
 
 BN.prototype.ishln = function ishln(bits) {
   // TODO(indutny): implement me
-  assert(this.sign === 0);
+  assert(this.negative === 0);
   return this.iushln(bits);
 };
 
@@ -1228,7 +1228,7 @@ BN.prototype.iushrn = function iushrn(bits, hint, extended) {
 
 BN.prototype.ishrn = function ishrn(bits, hint, extended) {
   // TODO(indutny): implement me
-  assert(this.sign === 0);
+  assert(this.negative === 0);
   return this.iushrn(bits, hint, extended);
 };
 
@@ -1274,7 +1274,7 @@ BN.prototype.imaskn = function imaskn(bits) {
   var r = bits % 26;
   var s = (bits - r) / 26;
 
-  assert(this.sign === 0, 'imaskn works only with positive numbers');
+  assert(this.negative === 0, 'imaskn works only with positive numbers');
 
   if (r !== 0)
     s++;
@@ -1300,16 +1300,16 @@ BN.prototype.iaddn = function iaddn(num) {
     return this.isubn(-num);
 
   // Possible sign change
-  if (this.sign !== 0) {
+  if (this.negative !== 0) {
     if (this.length === 1 && (this.words[0] | 0) < num) {
       this.words[0] = num - (this.words[0] | 0);
-      this.sign = 0;
+      this.negative = 0;
       return this;
     }
 
-    this.sign = 0;
+    this.negative = 0;
     this.isubn(num);
-    this.sign = 1;
+    this.negative = 1;
     return this;
   }
 
@@ -1339,10 +1339,10 @@ BN.prototype.isubn = function isubn(num) {
   if (num < 0)
     return this.iaddn(-num);
 
-  if (this.sign !== 0) {
-    this.sign = 0;
+  if (this.negative !== 0) {
+    this.negative = 0;
     this.iaddn(num);
-    this.sign = 1;
+    this.negative = 1;
     return this;
   }
 
@@ -1366,7 +1366,7 @@ BN.prototype.subn = function subn(num) {
 };
 
 BN.prototype.iabs = function iabs() {
-  this.sign = 0;
+  this.negative = 0;
 
   return this;
 };
@@ -1418,7 +1418,7 @@ BN.prototype._ishlnsubmul = function _ishlnsubmul(num, mul, shift) {
     carry = w >> 26;
     this.words[i] = w & 0x3ffffff;
   }
-  this.sign = 1;
+  this.negative = 1;
 
   return this.strip();
 };
@@ -1452,7 +1452,7 @@ BN.prototype._wordDiv = function _wordDiv(num, mode) {
   }
 
   var diff = a.clone()._ishlnsubmul(b, 1, m);
-  if (diff.sign === 0) {
+  if (diff.negative === 0) {
     a = diff;
     if (q)
       q.words[m] = 1;
@@ -1467,12 +1467,12 @@ BN.prototype._wordDiv = function _wordDiv(num, mode) {
     qj = Math.min((qj / bhi) | 0, 0x3ffffff);
 
     a._ishlnsubmul(b, qj, j);
-    while (a.sign === 1) {
+    while (a.negative !== 0) {
       qj--;
-      a.sign = 0;
+      a.negative = 0;
       a._ishlnsubmul(b, 1, j);
       if (a.cmpn(0) !== 0)
-        a.sign ^= 1;
+        a.negative ^= 1;
     }
     if (q)
       q.words[j] = qj;
@@ -1490,7 +1490,7 @@ BN.prototype._wordDiv = function _wordDiv(num, mode) {
 BN.prototype.divmod = function divmod(num, mode, positive) {
   assert(num.cmpn(0) !== 0);
 
-  if (this.sign !== 0 && num.sign === 0) {
+  if (this.negative !== 0 && num.negative === 0) {
     var res = this.neg().divmod(num, mode);
     var div;
     var mod;
@@ -1505,13 +1505,13 @@ BN.prototype.divmod = function divmod(num, mode, positive) {
       div: div,
       mod: mod
     };
-  } else if (this.sign === 0 && num.sign !== 0) {
+  } else if (this.negative === 0 && num.negative !== 0) {
     var res = this.divmod(num.neg(), mode);
     var div;
     if (mode !== 'mod')
       div = res.div.neg();
     return { div: div, mod: res.mod };
-  } else if ((this.sign & num.sign) !== 0) {
+  } else if ((this.negative & num.negative) !== 0) {
     var res = this.neg().divmod(num.neg(), mode);
     var mod;
     if (mode !== 'div') {
@@ -1568,7 +1568,7 @@ BN.prototype.divRound = function divRound(num) {
   if (dm.mod.cmpn(0) === 0)
     return dm.div;
 
-  var mod = dm.div.sign !== 0 ? dm.mod.isub(num) : dm.mod;
+  var mod = dm.div.negative !== 0 ? dm.mod.isub(num) : dm.mod;
 
   var half = num.ushrn(1);
   var r2 = num.andln(1);
@@ -1579,7 +1579,7 @@ BN.prototype.divRound = function divRound(num) {
     return dm.div;
 
   // Round up
-  return dm.div.sign !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
+  return dm.div.negative !== 0 ? dm.div.isubn(1) : dm.div.iaddn(1);
 };
 
 BN.prototype.modn = function modn(num) {
@@ -1612,13 +1612,13 @@ BN.prototype.divn = function divn(num) {
 };
 
 BN.prototype.egcd = function egcd(p) {
-  assert(p.sign === 0);
+  assert(p.negative === 0);
   assert(p.cmpn(0) !== 0);
 
   var x = this;
   var y = p.clone();
 
-  if (x.sign !== 0)
+  if (x.negative !== 0)
     x = x.umod(p);
   else
     x = x.clone();
@@ -1687,13 +1687,13 @@ BN.prototype.egcd = function egcd(p) {
 // above, designated to invert members of the
 // _prime_ fields F(p) at a maximal speed
 BN.prototype._invmp = function _invmp(p) {
-  assert(p.sign === 0);
+  assert(p.negative === 0);
   assert(p.cmpn(0) !== 0);
 
   var a = this;
   var b = p.clone();
 
-  if (a.sign !== 0)
+  if (a.negative !== 0)
     a = a.umod(p);
   else
     a = a.clone();
@@ -1747,8 +1747,8 @@ BN.prototype.gcd = function gcd(num) {
 
   var a = this.clone();
   var b = num.clone();
-  a.sign = 0;
-  b.sign = 0;
+  a.negative = 0;
+  b.negative = 0;
 
   // Remove common factor of two
   for (var shift = 0; a.isEven() && b.isEven(); shift++) {
@@ -1829,13 +1829,13 @@ BN.prototype.bincn = function bincn(bit) {
 };
 
 BN.prototype.cmpn = function cmpn(num) {
-  var sign = num < 0;
-  if (sign)
+  var negative = num < 0;
+  if (negative)
     num = -num;
 
-  if (this.sign !== 0 && !sign)
+  if (this.negative !== 0 && !negative)
     return -1;
-  else if (this.sign === 0 && sign)
+  else if (this.negative === 0 && negative)
     return 1;
 
   num &= 0x3ffffff;
@@ -1848,7 +1848,7 @@ BN.prototype.cmpn = function cmpn(num) {
     var w = this.words[0] | 0;
     res = w === num ? 0 : w < num ? -1 : 1;
   }
-  if (this.sign !== 0)
+  if (this.negative !== 0)
     res = -res;
   return res;
 };
@@ -1858,13 +1858,13 @@ BN.prototype.cmpn = function cmpn(num) {
 // 0 - if `this` == `num`
 // -1 - if `this` < `num`
 BN.prototype.cmp = function cmp(num) {
-  if (this.sign !== 0 && num.sign === 0)
+  if (this.negative !== 0 && num.negative === 0)
     return -1;
-  else if (this.sign === 0 && num.sign !== 0)
+  else if (this.negative === 0 && num.negative !== 0)
     return 1;
 
   var res = this.ucmp(num);
-  if (this.sign !== 0)
+  if (this.negative !== 0)
     return -res;
   else
     return res;
@@ -1904,7 +1904,7 @@ BN.red = function red(num) {
 
 BN.prototype.toRed = function toRed(ctx) {
   assert(!this.red, 'Already a number in reduction context');
-  assert(this.sign === 0, 'red works only with positives');
+  assert(this.negative === 0, 'red works only with positives');
   return ctx.convertTo(this)._forceRed(ctx);
 };
 
@@ -2201,12 +2201,12 @@ function Red(m) {
 }
 
 Red.prototype._verify1 = function _verify1(a) {
-  assert(a.sign === 0, 'red works only with positives');
+  assert(a.negative === 0, 'red works only with positives');
   assert(a.red, 'red works only with red numbers');
 };
 
 Red.prototype._verify2 = function _verify2(a, b) {
-  assert((a.sign | b.sign) === 0, 'red works only with positives');
+  assert((a.negative | b.negative) === 0, 'red works only with positives');
   assert(a.red && a.red === b.red,
          'red works only with red numbers');
 };
@@ -2219,7 +2219,7 @@ Red.prototype.imod = function imod(a) {
 
 Red.prototype.neg = function neg(a) {
   var r = a.clone();
-  r.sign ^= 1;
+  r.negative ^= 1;
   return r.iadd(this.m)._forceRed(this);
 };
 
@@ -2340,8 +2340,8 @@ Red.prototype.sqrt = function sqrt(a) {
 
 Red.prototype.invm = function invm(a) {
   var inv = a._invmp(this.m);
-  if (inv.sign !== 0) {
-    inv.sign = 0;
+  if (inv.negative !== 0) {
+    inv.negative = 0;
     return this.imod(inv).redNeg();
   } else {
     return this.imod(inv);

--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -38,17 +38,17 @@ describe('BN.js/Arithmetic', function() {
   describe('.iaddn()', function() {
     it('should allow a sign change', function() {
       var a = new BN(-100);
-      assert.equal(a.sign, true);
+      assert.equal(a.negative, 1);
 
       a.iaddn(200);
 
-      assert.equal(a.sign, false);
+      assert.equal(a.negative, 0);
       assert.equal(a.toString(), '100');
     });
 
     it('should add negative number', function() {
       var a = new BN(-100);
-      assert.equal(a.sign, true);
+      assert.equal(a.negative, 1);
 
       a.iaddn(-200);
 
@@ -57,7 +57,7 @@ describe('BN.js/Arithmetic', function() {
 
     it('should allow neg + pos with big number', function() {
       var a = new BN('-1000000000', 10);
-      assert.equal(a.sign, true);
+      assert.equal(a.negative, 1);
 
       a.iaddn(200);
 
@@ -121,19 +121,19 @@ describe('BN.js/Arithmetic', function() {
 
     it('should work for positive numbers', function() {
       var a = new BN(-100);
-      assert.equal(a.sign, true);
+      assert.equal(a.negative, 1);
 
       a.isubn(200);
-      assert.equal(a.sign, true);
+      assert.equal(a.negative, 1);
       assert.equal(a.toString(), '-300');
     });
 
     it('should not allow a sign change', function() {
       var a = new BN(-100);
-      assert.equal(a.sign, true);
+      assert.equal(a.negative, 1);
 
       a.isubn(-200);
-      assert.equal(a.sign, false);
+      assert.equal(a.negative, 0);
       assert.equal(a.toString(), '100');
     });
   });

--- a/test/red-test.js
+++ b/test/red-test.js
@@ -90,7 +90,7 @@ describe('BN.js/Reduction context', function() {
 
         var m = fn(p);
         var a = a.toRed(m);
-        assert.equal(a.redInvm().fromRed().sign, false);
+        assert.equal(a.redInvm().fromRed().negative, 0);
       });
 
       it('should imul numbers', function() {


### PR DESCRIPTION
Make `.sign` a plain integer instead of boolean. Possible values are
either `0` or `1`.

Other improvements:

- Peel first iteration of `smallMulTo`. This gives about 5% boost to
  multiplication
- Cast array loads to small integers, this gives about 5% boost to
  addition and probably other routines too

cc @calvinmetcalf This is probably going to be a major version bump. What are your thoughts on this?