### PR TITLE
add failing test for pow change

### DIFF
--- a/test/red-test.js
+++ b/test/red-test.js
@@ -172,4 +172,44 @@ describe('BN.js/Reduction context', function() {
       assert.equal(actual.toString(16), expected.toString(16));
     });
   });
+  it('should avoid 4.1.0 regresion', function () {
+    function bits2int (obits, q) {
+      var bits = new BN(obits)
+      var shift = (obits.length << 3) - q.bitLength()
+      if (shift > 0) {
+        bits.ishrn(shift)
+      }
+      return bits
+    }
+    var t = new Buffer('aff1651e4cd6036d57aa8b2a05ccf1a9d5a40166340ecbbdc55' +
+                       'be10b568aa0aa3d05ce9a2fcec9df8ed018e29683c6051cb83e' +
+                       '46ce31ba4edb045356a8d0d80b', 'hex');
+    var g = new BN('5c7ff6b06f8f143fe8288433493e4769c4d988ace5be25a0e24809670' +
+                   '716c613d7b0cee6932f8faa7c44d2cb24523da53fbe4f6ec3595892d1' +
+                   'aa58c4328a06c46a15662e7eaa703a1decf8bbb2d05dbe2eb956c142a' +
+                   '338661d10461c0d135472085057f3494309ffa73c611f78b32adbb574' +
+                   '0c361c9f35be90997db2014e2ef5aa61782f52abeb8bd6432c4dd097b' +
+                   'c5423b285dafb60dc364e8161f4a2a35aca3a10b1c4d203cc76a470a3' +
+                   '3afdcbdd92959859abd8b56e1725252d78eac66e71ba9ae3f1dd24871' +
+                   '99874393cd4d832186800654760e1e34c09e4d155179f9ec0dc4473f9' +
+                   '96bdce6eed1cabed8b6f116f7ad9cf505df0f998e34ab27514b0ffe7',
+                   16);
+    var p = new BN('9db6fb5951b66bb6fe1e140f1d2ce5502374161fd6538df1648218642' +
+                   'f0b5c48c8f7a41aadfa187324b87674fa1822b00f1ecf8136943d7c55' +
+                   '757264e5a1a44ffe012e9936e00c1d3e9310b01c7d179805d3058b2a9' +
+                   'f4bb6f9716bfe6117c6b5b3cc4d9be341104ad4a80ad6c94e005f4b99' +
+                   '3e14f091eb51743bf33050c38de235567e1b34c3d6a5c0ceaa1a0f368' +
+                   '213c3d19843d0b4b09dcb9fc72d39c8de41f1bf14d4bb4563ca283716' +
+                   '21cad3324b6a2d392145bebfac748805236f5ca2fe92b871cd8f9c36d' +
+                   '3292b5509ca8caa77a2adfc7bfd77dda6f71125a7456fea153e433256' +
+                   'a2261c6a06ed3693797e7995fad5aabbcfbe3eda2741e375404ae25b',
+                    16);
+    var q = new BN('f2c3119374ce76c9356990b465374a17f23f9ed35089bd969f61c6dde' +
+                   '9998c1f', 16);
+    var k = bits2int(t, q);
+    var expectedR = '89ec4bb1400eccff8e7d9aa515cd1de7803f2daff09693ee7fd1353e' +
+                    '90a68307';
+    var r = g.toRed(BN.mont(p)).redPow(k).fromRed().mod(q);
+    assert.equal(r.toString(16), expectedR);
+  })
 });


### PR DESCRIPTION
try 2 for a failing test for #63  the issue looks to be how k is setup internally as adding a 

```js
k = new BN(k.toString(16), 16);
```

causes the problem to go away, if you do that then the words before were

```js
[ 42639530,
        49824469,
        12311637,
        26791995,
        30778369,
        24329322,
        44610208,
        898398,
        18762966,
        2882649,
        0,
        24085549,
        46906821,
        5868803,
        43866688,
        1520582,
        61508394,
        25221973,
        38921421,
        180165,
        0,
        0 ]
```

but after are

```js
 [ 42639530,
        49824469,
        12311637,
        26791995,
        30778369,
        24329322,
        44610208,
        898398,
        18762966,
        2882649,
        0 ]
```