### PR TITLE
Introduce .toNumber()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
+sudo: false
 language: node_js
 node_js:
-  - "4.1"
-branches:
-  only:
-    - master
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+env:
+  matrix:
+    - TEST_SUITE=test
+matrix:
+  include:
+    - node_js: "4"
+      env: TEST_SUITE=lint
+script: npm run $TEST_SUITE

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ either `le` (little-endian) or `be` (big-endian).
 * `a.toArray(endian, length)` - convert to byte array, and optionally zero
   pad to length, throwing if already exceeding
 * `a.toString(base, padding)` - convert to base-string and pad with zeroes
+* `a.toNumber()` - convert to Javascript Number (limited to 53 bits)
 * `a.bitLength()` - get number of bits occupied
 * `a.zeroBits()` - return number of less-significant consequent zero bits
   (example: `1010000` has 4 zero bits)

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -452,7 +452,7 @@ BN.prototype.toString = function toString(base, padding) {
 
 BN.prototype.toNumber = function toNumber() {
   assert(this.bitLength() <= 53, 'Number can only safely store up to 53 bits');
-  return parseInt(this.toString());
+  return parseInt(this.toString(), 10);
 };
 
 BN.prototype.toJSON = function toJSON() {

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -450,6 +450,11 @@ BN.prototype.toString = function toString(base, padding) {
   }
 };
 
+BN.prototype.toNumber = function toNumber() {
+  assert(this.bitLength() <= 53, 'Number can only safely store up to 53 bits');
+  return parseInt(this.toString());
+};
+
 BN.prototype.toJSON = function toJSON() {
   return this.toString(16);
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Big number implementation in pure javascript",
   "main": "lib/bn.js",
   "scripts": {
-    "test": "mocha --reporter=spec test/*-test.js && jscs lib/*.js test/*.js && jshint lib/*.js"
+    "lint": "jscs lib/*.js test/*.js && jshint lib/*.js",
+    "test": "mocha --reporter=spec test/*-test.js"
   },
   "repository": {
     "type": "git",

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -163,6 +163,20 @@ describe('BN.js/Utils', function() {
     });
   });
 
+  describe('.toNumber()', function() {
+    it('should return proper Number if below the limit', function() {
+      var n = new BN(0x123456);
+      assert.deepEqual(n.toNumber(), 0x123456);
+    });
+
+    it('should throw when number exceeds 53 bits', function() {
+      var n = new BN(1).iushln(54);
+      assert.throws(function() {
+        n.toNumber();
+      });
+    });
+  });
+
   describe('.zeroBits()', function() {
     it('should return proper zeroBits', function() {
       assert.equal(new BN(0).zeroBits(), 0);

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -78,6 +78,28 @@ describe('BN.js/Utils', function() {
     });
   });
 
+  describe('.isOdd()', function() {
+    it('should return true for odd numbers', function() {
+      assert.equal(new BN(0).isOdd(), false);
+      assert.equal(new BN(1).isOdd(), true);
+      assert.equal(new BN(2).isOdd(), false);
+      assert.equal(new BN('-0', 10).isOdd(), false);
+      assert.equal(new BN('-1', 10).isOdd(), true);
+      assert.equal(new BN('-2', 10).isOdd(), false);
+    });
+  });
+
+  describe('.isEven()', function() {
+    it('should return true for even numbers', function() {
+      assert.equal(new BN(0).isEven(), true);
+      assert.equal(new BN(1).isEven(), false);
+      assert.equal(new BN(2).isEven(), true);
+      assert.equal(new BN('-0', 10).isEven(), true);
+      assert.equal(new BN('-1', 10).isEven(), false);
+      assert.equal(new BN('-2', 10).isEven(), true);
+    });
+  });
+
   describe('.bitLength()', function() {
     it('should return proper bitLength', function() {
       assert.equal(new BN(0).bitLength(), 0);
@@ -91,6 +113,22 @@ describe('BN.js/Utils', function() {
       assert.equal(new BN(0x123456).bitLength(), 21);
       assert.equal(new BN('123456789', 16).bitLength(), 33);
       assert.equal(new BN('8023456789', 16).bitLength(), 40);
+    });
+  });
+
+  describe('.byteLength()', function() {
+    it('should return proper byteLength', function() {
+      assert.equal(new BN(0).byteLength(), 0);
+      assert.equal(new BN(0x1).byteLength(), 1);
+      assert.equal(new BN(0x2).byteLength(), 1);
+      assert.equal(new BN(0x3).byteLength(), 1);
+      assert.equal(new BN(0x4).byteLength(), 1);
+      assert.equal(new BN(0x8).byteLength(), 1);
+      assert.equal(new BN(0x10).byteLength(), 1);
+      assert.equal(new BN(0x100).byteLength(), 2);
+      assert.equal(new BN(0x123456).byteLength(), 3);
+      assert.equal(new BN('123456789', 16).byteLength(), 5);
+      assert.equal(new BN('8023456789', 16).byteLength(), 5);
     });
   });
 


### PR DESCRIPTION
A simple wrapper around toString() to get the an actual number object in JS. Throws an error if its not safe to represent in JS.