### PR TITLE
Add .toBuffer() to return a node.js Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ either `le` (little-endian) or `be` (big-endian).
   pad to length, throwing if already exceeding
 * `a.toString(base, padding)` - convert to base-string and pad with zeroes
 * `a.toNumber()` - convert to Javascript Number (limited to 53 bits)
+* `a.toBuffer()` - convert to Node.js Buffer (if available)
 * `a.bitLength()` - get number of bits occupied
 * `a.zeroBits()` - return number of less-significant consequent zero bits
   (example: `1010000` has 4 zero bits)

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -53,7 +53,7 @@
 
   var Buffer;
   try {
-    Buffer = require('buf' + 'fer').Buffer;
+    Buffer = require('buffer').Buffer;
   } catch (e) {
   }
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -50,7 +50,12 @@
 
   BN.BN = BN;
   BN.wordSize = 26;
-  BN._hasBuffer = typeof Buffer !== 'undefined';
+
+  try {
+    BN._Buffer = require('buf' + 'fer').Buffer;
+  } catch (e) {
+    BN._Buffer = undefined;
+  }
 
   BN.max = function max (left, right) {
     if (left.cmp(right) > 0) return left;
@@ -497,8 +502,8 @@
   };
 
   BN.prototype.toBuffer = function toBuffer (endian, length) {
-    assert(BN._hasBuffer);
-    return new Buffer(this.toArray(endian, length));
+    assert(typeof BN._Buffer !== 'undefined');
+    return new BN._Buffer(this.toArray(endian, length));
   };
 
   BN.prototype.toArray = function toArray (endian, length) {

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -51,10 +51,10 @@
   BN.BN = BN;
   BN.wordSize = 26;
 
+  var Buffer;
   try {
-    BN._Buffer = require('buf' + 'fer').Buffer;
+    Buffer = require('buf' + 'fer').Buffer;
   } catch (e) {
-    BN._Buffer = undefined;
   }
 
   BN.max = function max (left, right) {
@@ -502,8 +502,8 @@
   };
 
   BN.prototype.toBuffer = function toBuffer (endian, length) {
-    assert(typeof BN._Buffer !== 'undefined');
-    return new BN._Buffer(this.toArray(endian, length));
+    assert(typeof Buffer !== 'undefined');
+    return new Buffer(this.toArray(endian, length));
   };
 
   BN.prototype.toArray = function toArray (endian, length) {

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -495,6 +495,10 @@
     return this.toString(16);
   };
 
+  BN.prototype.toBuffer = function toBuffer (endian, length) {
+    return new Buffer(this.toArray(endian, length));
+  };
+
   BN.prototype.toArray = function toArray (endian, length) {
     var byteLength = this.byteLength();
     var reqLength = length || Math.max(1, byteLength);

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -50,6 +50,7 @@
 
   BN.BN = BN;
   BN.wordSize = 26;
+  BN._hasBuffer = typeof Buffer !== 'undefined';
 
   BN.max = function max (left, right) {
     if (left.cmp(right) > 0) return left;
@@ -496,6 +497,7 @@
   };
 
   BN.prototype.toBuffer = function toBuffer (endian, length) {
+    assert(BN._hasBuffer);
     return new Buffer(this.toArray(endian, length));
   };
 

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
     "semistandard": "^7.0.4"
+  },
+  "browser" : {
+    "buffer": false
   }
 }

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -125,6 +125,21 @@ describe('BN.js/Constructor', function () {
     });
   });
 
+  // the Array code is able to handle Buffer
+  describe('with Buffer input', function () {
+    it('should not fail on empty Buffer', function () {
+      assert.equal(new BN(new Buffer(0)).toString(16), '0');
+    });
+
+    it('should import/export big endian', function () {
+      assert.equal(new BN(new Buffer('010203', 'hex')).toString(16), '10203');
+    });
+
+    it('should import little endian', function () {
+      assert.equal(new BN(new Buffer('010203', 'hex'), 'le').toString(16), '30201');
+    });
+  });
+
   describe('with BN input', function () {
     it('should clone BN', function () {
       var num = new BN(12345);

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -141,6 +141,14 @@ describe('BN.js/Utils', function () {
     });
   });
 
+  describe('.toBuffer', function () {
+    it('should return proper Buffer', function () {
+      var n = new BN(0x123456);
+      assert.deepEqual(n.toBuffer('be', 5).toString('hex'), '0000123456');
+      assert.deepEqual(n.toBuffer('le', 5).toString('hex'), '5634120000');
+    });
+  });
+
   describe('.toNumber()', function () {
     it('should return proper Number if below the limit', function () {
       assert.deepEqual(new BN(0x123456).toNumber(), 0x123456);


### PR DESCRIPTION
As the constructor already supports Buffer as an input, it would make sense to make this bidirectional.

Buffer+BN together is used extensively in ethereumjs-vm and ethereumjs-abi to encode/decode bytecode.

Added the .toBuffer() as a new feature which asserts on Buffer being present. Comes with its own test.

Also added tests for using Buffer as an input to the constructor.