### PR TITLE
Support bitwise NOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ either `le` (little-endian) or `be` (big-endian).
 * `a.testn(b)` - test if specified bit is set
 * `a.maskn(b)` - clear bits with indexes higher or equal to `b` (`i`)
 * `a.bincn(b)` - add `1 << b` to the number
-* `a.notn(w)` - not (for the width specified by `w`)
+* `a.notn(w)` - not (for the width specified by `w`) (`i`)
 
 ### Reduction
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ either `le` (little-endian) or `be` (big-endian).
 * `a.testn(b)` - test if specified bit is set
 * `a.maskn(b)` - clear bits with indexes higher or equal to `b` (`i`)
 * `a.bincn(b)` - add `1 << b` to the number
+* `a.notn(w)` - not (for the width specified by `w`)
 
 ### Reduction
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -748,16 +748,16 @@ BN.prototype.inotn = function inotn(width) {
 
   // Handle complete words
   for (var i = 0; i < bytesNeeded; i++) {
-    var tmp = this.words[i] & 0xfc000000;
-    this.words[i] = tmp | (~(this.words[i] & 0x3ffffff)) & 0x3ffffff;
+    this.words[i] = (this.words[i] & 0xfc000000) |
+                    ((~(this.words[i] & 0x3ffffff)) & 0x3ffffff);
   }
 
   // Handle the residue
   if (bitsLeft > 0) {
     var tmask = 0xfc000000 | ((0xffffffff >> bitsLeft) << bitsLeft);
     var bmask = 0x3ffffff >> (26 - bitsLeft);
-    var tmp = this.words[i] & tmask;
-    this.words[i] = tmp | (~(this.words[i] & bmask)) & bmask;
+    this.words[i] = (this.words[i] & tmask) |
+                    ((~(this.words[i] & bmask)) & bmask);
   }
 
   // And remove leading zeroes

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -736,15 +736,18 @@ BN.prototype.inotn = function inotn(width) {
   assert(typeof width === 'number' && width >= 0);
 
   var bytesNeeded = Math.ceil(width / 26) | 0;
-  var bitsLeft = width;
+  var bitsLeft = width % 26;
 
   // Extend the buffer with leading zeroes
   while (this.length < bytesNeeded) {
     this.words[this.length++] = 0;
   }
 
+  if (bitsLeft > 0)
+    bytesNeeded--;
+
   // Handle complete words
-  for (var i = 0; i < bytesNeeded && bitsLeft >= 26; i++, bitsLeft -= 26) {
+  for (var i = 0; i < bytesNeeded; i++) {
     var tmp = this.words[i] & 0xfc000000;
     this.words[i] = tmp | (~(this.words[i] & 0x3ffffff)) & 0x3ffffff;
   }

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -735,7 +735,7 @@ BN.prototype.uxor = function uxor(num) {
 BN.prototype.inotn = function inotn(width) {
   assert(typeof width === 'number' && width >= 0);
 
-  var bytesNeeded = width / 26;
+  var bytesNeeded = Math.ceil(width / 26) | 0;
 
   // Extend the buffer with leading zeroes
   while (this.length < bytesNeeded) {

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -732,8 +732,41 @@ BN.prototype.uxor = function uxor(num) {
 
 
 // Not ``this`` with ``width`` bitwidth
+BN.prototype.inotn = function inotn(width) {
+  assert(typeof width === 'number' && width >= 0);
+
+  var bytesNeeded = width / 26;
+
+  // Extend the buffer with leading zeroes
+  while (this.length < bytesNeeded) {
+    this.words[this.length++] = 0;
+  }
+
+  for (var i = 0; i < bytesNeeded; i++) {
+    var tmask = 0xfc000000; // top field
+    var bmask = 0x3ffffff;  // bottom field
+
+    if (width < 26) {
+      // keep the bottom <width> bits
+      bmask >>= (26 - width);
+      // increase the top mask
+      tmask |= (tmask >> width) << width;
+    }
+    width -= 26;
+
+    // NOT the bottom field and leave the top intact
+    var tmp = this.words[i] & tmask;
+    this.words[i] = tmp | (~(this.words[i] & bmask)) & bmask;
+  }
+
+  // And remove leading zeroes
+  this.strip();
+
+  return this;
+};
+
 BN.prototype.notn = function notn(width) {
-  return new BN(1).iushln(width).isubn(1).isub(this);
+  return this.clone().inotn(width);
 };
 
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -748,13 +748,12 @@ BN.prototype.inotn = function inotn(width) {
 
   // Handle complete words
   for (var i = 0; i < bytesNeeded; i++) {
-    this.words[i] = (~(this.words[i] & 0x3ffffff)) & 0x3ffffff;
+    this.words[i] = ~this.words[i] & 0x3ffffff;
   }
 
   // Handle the residue
   if (bitsLeft > 0) {
-    var mask = 0x3ffffff >> (26 - bitsLeft);
-    this.words[i] = (~(this.words[i] & mask)) & mask;
+    this.words[i] = ~this.words[i] & (0x3ffffff >> (26 - bitsLeft));
   }
 
   // And remove leading zeroes

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -743,19 +743,16 @@ BN.prototype.inotn = function inotn(width) {
     this.words[this.length++] = 0;
   }
 
-  for (var i = 0; i < bytesNeeded; i++) {
-    var tmask = 0xfc000000; // top field
-    var bmask = 0x3ffffff;  // bottom field
+  // Handle complete words
+  for (var i = 0; i < bytesNeeded && bitsLeft >= 26; i++, bitsLeft -= 26) {
+    var tmp = this.words[i] & 0xfc000000;
+    this.words[i] = tmp | (~(this.words[i] & 0x3ffffff)) & 0x3ffffff;
+  }
 
-    if (bitsLeft < 26) {
-      // keep the bottom <width> bits
-      bmask >>= (26 - bitsLeft);
-      // increase the top mask
-      tmask |= (tmask >> bitsLeft) << bitsLeft;
-    }
-    bitsLeft -= 26;
-
-    // NOT the bottom field and leave the top intact
+  // Handle the residue
+  if (bitsLeft > 0) {
+    var tmask = 0xfc000000 | ((0xffffffff >> bitsLeft) << bitsLeft);
+    var bmask = 0x3ffffff >> (26 - bitsLeft);
     var tmp = this.words[i] & tmask;
     this.words[i] = tmp | (~(this.words[i] & bmask)) & bmask;
   }

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -748,16 +748,13 @@ BN.prototype.inotn = function inotn(width) {
 
   // Handle complete words
   for (var i = 0; i < bytesNeeded; i++) {
-    this.words[i] = (this.words[i] & 0xfc000000) |
-                    ((~(this.words[i] & 0x3ffffff)) & 0x3ffffff);
+    this.words[i] = (~(this.words[i] & 0x3ffffff)) & 0x3ffffff;
   }
 
   // Handle the residue
   if (bitsLeft > 0) {
-    var tmask = 0xfc000000 | ((0xffffffff >> bitsLeft) << bitsLeft);
-    var bmask = 0x3ffffff >> (26 - bitsLeft);
-    this.words[i] = (this.words[i] & tmask) |
-                    ((~(this.words[i] & bmask)) & bmask);
+    var mask = 0x3ffffff >> (26 - bitsLeft);
+    this.words[i] = (~(this.words[i] & mask)) & mask;
   }
 
   // And remove leading zeroes

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -731,6 +731,12 @@ BN.prototype.uxor = function uxor(num) {
 };
 
 
+// Not ``this`` with ``width`` bitwidth
+BN.prototype.notn = function notn(width) {
+  return new BN(1).iushln(width).isubn(1).isub(this);
+};
+
+
 // Set `bit` of `this`
 BN.prototype.setn = function setn(bit, val) {
   assert(typeof bit === 'number' && bit >= 0);

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -736,6 +736,7 @@ BN.prototype.inotn = function inotn(width) {
   assert(typeof width === 'number' && width >= 0);
 
   var bytesNeeded = Math.ceil(width / 26) | 0;
+  var bitsLeft = width;
 
   // Extend the buffer with leading zeroes
   while (this.length < bytesNeeded) {
@@ -746,13 +747,13 @@ BN.prototype.inotn = function inotn(width) {
     var tmask = 0xfc000000; // top field
     var bmask = 0x3ffffff;  // bottom field
 
-    if (width < 26) {
+    if (bitsLeft < 26) {
       // keep the bottom <width> bits
-      bmask >>= (26 - width);
+      bmask >>= (26 - bitsLeft);
       // increase the top mask
-      tmask |= (tmask >> width) << width;
+      tmask |= (tmask >> bitsLeft) << bitsLeft;
     }
-    width -= 26;
+    bitsLeft -= 26;
 
     // NOT the bottom field and leave the top intact
     var tmp = this.words[i] & tmask;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -760,9 +760,7 @@ BN.prototype.inotn = function inotn(width) {
   }
 
   // And remove leading zeroes
-  this.strip();
-
-  return this;
+  return this.strip();
 };
 
 BN.prototype.notn = function notn(width) {

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -197,4 +197,28 @@ describe('BN.js/Binary', function() {
       assert.equal(new BN('101', 2).setn(2, false).toString(2), '1');
     });
   });
+
+  describe('.notn()', function() {
+    it('should allow bitwise negation', function () {
+      assert.equal(new BN('111000111', 2).notn(9).toString(2),
+                   '111000');
+      assert.equal(new BN('000111000', 2).notn(9).toString(2),
+                   '111000111');
+      assert.equal(new BN('111000111', 2).notn(9).toString(2),
+                   '111000');
+      assert.equal(new BN('000111000', 2).notn(9).toString(2),
+                   '111000111');
+      assert.equal(new BN('111000111', 2).notn(32).toString(2),
+                   '11111111111111111111111000111000');
+      assert.equal(new BN('000111000', 2).notn(32).toString(2),
+                   '11111111111111111111111111000111');
+      assert.equal(new BN('111000111', 2).notn(68).toString(2),
+                   '11111111111111111111111111111111' +
+                   '111111111111111111111111111000111000');
+      assert.equal(new BN('000111000', 2).notn(68).toString(2),
+                   '11111111111111111111111111111111' +
+                   '111111111111111111111111111111000111');
+    });
+  });
+
 });


### PR DESCRIPTION
Implements the interface discussed in https://github.com/indutny/bn.js/issues/72.

Note that I've kept the lazy shift based implementation as the first commit. The second commit using the data directly is twice as fast according to the benchmarks. (Created my own benchmarks based on the benchmarking tool in the tree.)