### PR TITLE
bn: introduce '.isZero()'

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ either `le` (little-endian) or `be` (big-endian).
 * `a.isNeg()` - true if the number is negative
 * `a.isEven()` - no comments
 * `a.isOdd()` - no comments
+* `a.isZero()` - no comments
 * `a.cmp(b)` - compare numbers and return `-1` (`<`), `0` (`==`), or `1` (`>`)
   depending on the comparison result (`ucmp`, `cmpn`)
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -3195,6 +3195,10 @@ BN.prototype.bincn = function bincn(bit) {
   return this;
 };
 
+BN.prototype.isZero = function isZero() {
+  return this.length === 1 && this.words[0] === 0;
+};
+
 BN.prototype.cmpn = function cmpn(num) {
   var negative = num < 0;
   if (negative)

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -78,6 +78,14 @@ describe('BN.js/Utils', function() {
     });
   });
 
+  describe('.isZero()', function() {
+    it('should return true for zero', function() {
+      assert.equal(new BN(0).isZero(), true);
+      assert.equal(new BN(1).isZero(), false);
+      assert.equal(new BN(0xffffffff).isZero(), false);
+    });
+  });
+
   describe('.bitLength()', function() {
     it('should return proper bitLength', function() {
       assert.equal(new BN(0).bitLength(), 0);


### PR DESCRIPTION
As the title says.

The actual code is taken from here:
```
BN.prototype._normSign = function _normSign() {
  // -0 = 0
  if (this.length === 1 && this.words[0] === 0)
    this.negative = 0;
  return this;
};
```

The aim is to replace all the various suboptimal checks for zero (like ```if (this.cmpn(0) === 0)```) with this.

(Of course I am doing zero-checks in my tools too, so it is handy there too)