### PR TITLE
bn: optimise toArray to not use push/unshift

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -460,19 +460,24 @@ BN.prototype.toJSON = function toJSON() {
 };
 
 BN.prototype.toArray = function toArray(endian, length) {
+  var byteLength = this.byteLength();
+  length = length || byteLength;
+  assert(byteLength <= length, 'byte array longer than desired length');
+
   this.strip();
   var littleEndian = endian === 'le';
-  var res = new Array(this.byteLength());
-  res[0] = 0;
+  var res = new Array(length);
 
   var q = this.clone();
   if (!littleEndian) {
     // Assume big-endian
-    for (var i = 0; q.cmpn(0) !== 0; i++) {
+    for (var i = 0; i < length - byteLength; i++)
+      res[i] = 0;
+    for (i = 0; q.cmpn(0) !== 0; i++) {
       var b = q.andln(0xff);
       q.iushrn(8);
 
-      res[res.length - i - 1] = b;
+      res[length - i - 1] = b;
     }
   } else {
     for (var i = 0; q.cmpn(0) !== 0; i++) {
@@ -481,17 +486,8 @@ BN.prototype.toArray = function toArray(endian, length) {
 
       res[i] = b;
     }
-  }
-
-  if (length) {
-    assert(res.length <= length, 'byte array longer than desired length');
-
-    while (res.length < length) {
-      if (littleEndian)
-        res.push(0);
-      else
-        res.unshift(0);
-    }
+    for (; i < length; i++)
+      res[i] = 0;
   }
 
   return res;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -461,23 +461,23 @@ BN.prototype.toJSON = function toJSON() {
 
 BN.prototype.toArray = function toArray(endian, length) {
   var byteLength = this.byteLength();
-  length = length || byteLength;
-  assert(byteLength <= length, 'byte array longer than desired length');
+  var reqLength = length || byteLength;
+  assert(byteLength <= reqLength, 'byte array longer than desired length');
 
   this.strip();
   var littleEndian = endian === 'le';
-  var res = new Array(length);
+  var res = new Array(reqLength);
 
   var q = this.clone();
   if (!littleEndian) {
     // Assume big-endian
-    for (var i = 0; i < length - byteLength; i++)
+    for (var i = 0; i < reqLength - byteLength; i++)
       res[i] = 0;
     for (i = 0; q.cmpn(0) !== 0; i++) {
       var b = q.andln(0xff);
       q.iushrn(8);
 
-      res[length - i - 1] = b;
+      res[reqLength - i - 1] = b;
     }
   } else {
     for (var i = 0; q.cmpn(0) !== 0; i++) {
@@ -486,7 +486,7 @@ BN.prototype.toArray = function toArray(endian, length) {
 
       res[i] = b;
     }
-    for (; i < length; i++)
+    for (; i < reqLength; i++)
       res[i] = 0;
   }
 


### PR DESCRIPTION
This change is required to implement ```toArrayLike``` functionality requested in https://github.com/indutny/bn.js/pull/76