### PR TITLE
bn: add lt/gt/eq shorthands for comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ either `le` (little-endian) or `be` (big-endian).
 * `a.isZero()` - no comments
 * `a.cmp(b)` - compare numbers and return `-1` (a `<` b), `0` (a `==` b), or `1` (a `>` b)
   depending on the comparison result (`ucmp`, `cmpn`)
+* `a.lt(b)` - `a` less than `b` (`n`)
+* `a.lte(b)` - `a` less than or equals `b` (`n`)
+* `a.gt(b)` - `a` greater than `b` (`n`)
+* `a.gte(b)` - `a` greater than or equals `b` (`n`)
+* `a.eq(b)` - `a` equals `b` (`n`)
 
 ### Arithmetics
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -2723,6 +2723,46 @@
     return res;
   };
 
+  BN.prototype.gtn = function gtn (num) {
+    return this.cmpn(num) === 1;
+  };
+
+  BN.prototype.gt = function gt (num) {
+    return this.cmp(num) === 1;
+  };
+
+  BN.prototype.gten = function gten (num) {
+    return this.cmpn(num) >= 0;
+  };
+
+  BN.prototype.gte = function gte (num) {
+    return this.cmp(num) >= 0;
+  };
+
+  BN.prototype.ltn = function ltn (num) {
+    return this.cmpn(num) === -1;
+  };
+
+  BN.prototype.lt = function lt (num) {
+    return this.cmp(num) === -1;
+  };
+
+  BN.prototype.lten = function lten (num) {
+    return this.cmpn(num) <= 0;
+  };
+
+  BN.prototype.lte = function lte (num) {
+    return this.cmp(num) <= 0;
+  };
+
+  BN.prototype.eqn = function eqn (num) {
+    return this.cmpn(num) === 0;
+  };
+
+  BN.prototype.eq = function eq (num) {
+    return this.cmp(num) === 0;
+  };
+
   //
   // A reduce context, could be using montgomery or something better, depending
   // on the `m` itself.

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -207,4 +207,57 @@ describe('BN.js/Utils', function () {
       assert.equal(new BN(-42).cmp(new BN(-42)), 0);
     });
   });
+
+  describe('comparison shorthands', function () {
+    it('.gtn greater than', function () {
+      assert.equal(new BN(3).gtn(2), true);
+      assert.equal(new BN(3).gtn(3), false);
+      assert.equal(new BN(3).gtn(4), false);
+    });
+    it('.gt greater than', function () {
+      assert.equal(new BN(3).gt(new BN(2)), true);
+      assert.equal(new BN(3).gt(new BN(3)), false);
+      assert.equal(new BN(3).gt(new BN(4)), false);
+    });
+    it('.gten greater than or equal', function () {
+      assert.equal(new BN(3).gten(3), true);
+      assert.equal(new BN(3).gten(2), true);
+      assert.equal(new BN(3).gten(4), false);
+    });
+    it('.gte greater than or equal', function () {
+      assert.equal(new BN(3).gte(new BN(3)), true);
+      assert.equal(new BN(3).gte(new BN(2)), true);
+      assert.equal(new BN(3).gte(new BN(4)), false);
+    });
+    it('.ltn less than', function () {
+      assert.equal(new BN(2).ltn(3), true);
+      assert.equal(new BN(2).ltn(2), false);
+      assert.equal(new BN(2).ltn(1), false);
+    });
+    it('.lt less than', function () {
+      assert.equal(new BN(2).lt(new BN(3)), true);
+      assert.equal(new BN(2).lt(new BN(2)), false);
+      assert.equal(new BN(2).lt(new BN(1)), false);
+    });
+    it('.lten less than or equal', function () {
+      assert.equal(new BN(3).lten(3), true);
+      assert.equal(new BN(3).lten(2), false);
+      assert.equal(new BN(3).lten(4), true);
+    });
+    it('.lte less than or equal', function () {
+      assert.equal(new BN(3).lte(new BN(3)), true);
+      assert.equal(new BN(3).lte(new BN(2)), false);
+      assert.equal(new BN(3).lte(new BN(4)), true);
+    });
+    it('.eqn equal', function () {
+      assert.equal(new BN(3).eqn(3), true);
+      assert.equal(new BN(3).eqn(2), false);
+      assert.equal(new BN(3).eqn(4), false);
+    });
+    it('.eq equal', function () {
+      assert.equal(new BN(3).eq(new BN(3)), true);
+      assert.equal(new BN(3).eq(new BN(2)), false);
+      assert.equal(new BN(3).eq(new BN(4)), false);
+    });
+  });
 });


### PR DESCRIPTION
Adds lt/gt/eq (and n-postfixed versions) for a quick and user friendly helper. I still expect speed sensitive (and internal) methods to rely on `cmp`.

In terms of size: 40722 vs 41242 bytes when minified.