### PR TITLE
Add helper .isBN() to check if the supplied object is a BN.js instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ either `le` (little-endian) or `be` (big-endian).
 * `a.eq(b)` - `a` equals `b` (`n`)
 * `a.toTwos(width)` - convert to two's complement representation, where `width` is bit width
 * `a.fromTwos(width)` - convert from two's complement representation, where `width` is the bit width
+* `a.isBN(object)` - returns true if the supplied `object` is a BN.js instance
 
 ### Arithmetics
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -58,8 +58,8 @@
   }
 
   BN.isBN = function isBN (num) {
-    return (typeof num === 'object') &&
-      Array.isArray(num.words);
+    return (num !== null) && (typeof num === 'object') &&
+      (num.constructor.name === 'BN') && Array.isArray(num.words);
   };
 
   BN.max = function max (left, right) {

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -57,6 +57,11 @@
   } catch (e) {
   }
 
+  BN.isBN = function isBN (num) {
+    return (typeof num === 'object') &&
+      Array.isArray(num.words);
+  };
+
   BN.max = function max (left, right) {
     if (left.cmp(right) > 0) return left;
     return right;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -19,10 +19,7 @@
   // BN
 
   function BN (number, base, endian) {
-    // May be `new BN(bn)` ?
-    if (number !== null &&
-      typeof number === 'object' &&
-      Array.isArray(number.words)) {
+    if (BN.isBN(number)) {
       return number;
     }
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -55,8 +55,8 @@
   }
 
   BN.isBN = function isBN (num) {
-    return (num !== null) && (typeof num === 'object') &&
-      (num.constructor.name === 'BN') && Array.isArray(num.words);
+    return num !== null && typeof num === 'object' &&
+      num.constructor.name === 'BN' && Array.isArray(num.words);
   };
 
   BN.max = function max (left, right) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -330,4 +330,16 @@ describe('BN.js/Utils', function () {
         '8000000000000000000000000000000000000000000000000000000000000000');
     });
   });
+
+  describe('.isBN', function () {
+    it('should return true for BN', function () {
+      assert.equal(BN.isBN(new BN()), true);
+    });
+
+    it('should return false for everything else', function () {
+      assert.equal(BN.isBN(1), false);
+      assert.equal(BN.isBN([]), false);
+      assert.equal(BN.isBN({}), false);
+    });
+  });
 });


### PR DESCRIPTION
The logic is the same as in the constructor:
```js
  function BN (number, base, endian) {
    // May be `new BN(bn)` ?
    if (number !== null &&
      typeof number === 'object' &&
      Array.isArray(number.words)) {
      return number;
    }
    ...
```

It also could replace this part in the constructor, albeit I assume that could lead to a minor speed penalty in cases