### PR TITLE
bn: introduce .toArrayLike() to speedup .toBuffer()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ either `le` (little-endian) or `be` (big-endian).
 * `a.toString(base, padding)` - convert to base-string and pad with zeroes
 * `a.toNumber()` - convert to Javascript Number (limited to 53 bits)
 * `a.toBuffer()` - convert to Node.js Buffer (if available)
+* `a.toArrayLike(type)` - convert to an instance of `type`, which must behave like an `Array`
 * `a.bitLength()` - get number of bits occupied
 * `a.zeroBits()` - return number of less-significant consequent zero bits
   (example: `1010000` has 4 zero bits)

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -503,10 +503,14 @@
 
   BN.prototype.toBuffer = function toBuffer (endian, length) {
     assert(typeof Buffer !== 'undefined');
-    return new Buffer(this.toArray(endian, length));
+    return this.toArrayLike(Buffer, endian, length);
   };
 
   BN.prototype.toArray = function toArray (endian, length) {
+    return this.toArrayLike(Array, endian, length);
+  };
+
+  BN.prototype.toArrayLike = function toArrayLike (ArrayType, endian, length) {
     var byteLength = this.byteLength();
     var reqLength = length || Math.max(1, byteLength);
     assert(byteLength <= reqLength, 'byte array longer than desired length');
@@ -514,7 +518,7 @@
 
     this.strip();
     var littleEndian = endian === 'le';
-    var res = new Array(reqLength);
+    var res = new ArrayType(reqLength);
 
     var b, i;
     var q = this.clone();


### PR DESCRIPTION
As discussed in https://github.com/indutny/bn.js/pull/76