### PR TITLE
remove blacklisting of buffer in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
     "semistandard": "^7.0.4"
-  },
-  "browser": {
-    "buffer": false
   }
 }


### PR DESCRIPTION
The removed json mess up browserify by not letting it shim Buffer.  