### PR TITLE
bn: fix .toBuffer() inclusion and revert to old way (fixes #115)

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -53,7 +53,7 @@
 
   var Buffer;
   try {
-    Buffer = require('buffer').Buffer;
+    Buffer = require('buf' + 'fer').Buffer;
   } catch (e) {
   }
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
     "semistandard": "^7.0.4"
-  },
-  "browser": {
-    "buffer": false
   }
 }


### PR DESCRIPTION
This is a better fix to the problem reported in #115 