### PR TITLE
bn: fix K256.split

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -2999,8 +2999,13 @@
       input.words[i - 10] = ((next & mask) << 4) | (prev >>> 22);
       prev = next;
     }
-    input.words[i - 10] = prev >>> 22;
-    input.length -= 9;
+    prev >>>= 22;
+    input.words[i - 10] = prev;
+    if (prev === 0 && input.length > 10) {
+      input.length -= 10;
+    } else {
+      input.length -= 9;
+    }
   };
 
   K256.prototype.imulK = function imulK (num) {

--- a/test/red-test.js
+++ b/test/red-test.js
@@ -231,4 +231,13 @@ describe('BN.js/Reduction context', function () {
     var r = g.toRed(BN.mont(p)).redPow(k).fromRed().mod(q);
     assert.equal(r.toString(16), expectedR);
   });
+
+  it('K256.split for 512 bits number should return equal numbers', function () {
+    var red = BN.red('k256');
+    var input = new BN(1).iushln(512).subn(1);
+    assert.equal(input.bitLength(), 512);
+    var output = new BN(0);
+    red.prime.split(input, output);
+    assert.equal(input.cmp(output), 0);
+  });
 });


### PR DESCRIPTION
`K256.split` return wrong length in some cases:
```js
var BN = require('bn.js')
var red = BN.red('k256')
var input = new BN()
input.words = [0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff,
               0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff,
               0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff,
               0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x0003ffff]
input.length = 20
var output = new BN()
output.words = []
red.prime.split(input, output)
console.log(input.cmp(output))
console.log(input.length, output.length)
```