### PR TITLE
bn: fix .iaddn & .isubn for numbers > 0x3ffffff

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -1883,6 +1883,7 @@
 
   BN.prototype.imuln = function imuln (num) {
     assert(typeof num === 'number');
+    assert(num < 0x4000000);
 
     // Carry
     var carry = 0;
@@ -2114,6 +2115,7 @@
   // Add plain number `num` to `this`
   BN.prototype.iaddn = function iaddn (num) {
     assert(typeof num === 'number');
+    assert(num < 0x4000000);
     if (num < 0) return this.isubn(-num);
 
     // Possible sign change
@@ -2154,6 +2156,7 @@
   // Subtract plain number `num` from `this`
   BN.prototype.isubn = function isubn (num) {
     assert(typeof num === 'number');
+    assert(num < 0x4000000);
     if (num < 0) return this.iaddn(-num);
 
     if (this.negative !== 0) {

--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -77,6 +77,12 @@ describe('BN.js/Arithmetic', function () {
 
       assert.equal(a.iaddn(1).toString(16), '4000000');
     });
+
+    it('should throw error with num eq 0x4000000', function () {
+      assert.throws(function () {
+        new BN(0).iaddn(0x4000000);
+      });
+    });
   });
 
   describe('.sub()', function () {
@@ -153,6 +159,12 @@ describe('BN.js/Arithmetic', function () {
     it('should change sign on small numbers at 1', function () {
       var a = new BN(1).subn(2);
       assert.equal(a.toString(), '-1');
+    });
+
+    it('should throw error with num eq 0x4000000', function () {
+      assert.throws(function () {
+        new BN(0).isubn(0x4000000);
+      });
     });
   });
 
@@ -271,6 +283,12 @@ describe('BN.js/Arithmetic', function () {
       var c = a.mul(b);
 
       assert.equal(a.muln(0xdead).toString(16), c.toString(16));
+    });
+
+    it('should throw error with num eq 0x4000000', function () {
+      assert.throws(function () {
+        new BN(0).imuln(0x4000000);
+      });
     });
   });
 


### PR DESCRIPTION
Details #119 
It can be possible add numbers that more than 0x03ffffff (like in [_initNumber](https://github.com/indutny/bn.js/blob/2fbe7a3683aca9a6a09697a9af2ea7a05d42bf06/lib/bn.js#L112)), but it has overhead. If somebody need add this numbers, he can write `.add(new BN(num))`.