### PR TITLE
Use expand() for increasing the words[] array. Speeds up divmod a tiny bit.

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -797,9 +797,7 @@
     var bitsLeft = width % 26;
 
     // Extend the buffer with leading zeroes
-    while (this.length < bytesNeeded) {
-      this.words[this.length++] = 0;
-    }
+    this._expand(bytesNeeded);
 
     if (bitsLeft > 0) {
       bytesNeeded--;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -2690,17 +2690,14 @@
 
     // Fast case: bit is much higher than all existing words
     if (this.length <= s) {
-      for (var i = this.length; i < s + 1; i++) {
-        this.words[i] = 0;
-      }
+      this._expand(s + 1);
       this.words[s] |= q;
-      this.length = s + 1;
       return this;
     }
 
     // Add bit and propagate, if needed
     var carry = q;
-    for (i = s; carry !== 0 && i < this.length; i++) {
+    for (var i = s; carry !== 0 && i < this.length; i++) {
       var w = this.words[i] | 0;
       w += carry;
       carry = w >>> 26;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -315,6 +315,13 @@
     return r;
   };
 
+  BN.prototype._expand = function _expand (size) {
+    while (this.length < size) {
+      this.words[this.length++] = 0;
+    }
+    return this;
+  };
+
   // Remove leading `0` from `this`
   BN.prototype.strip = function strip () {
     while (this.length > 1 && this.words[this.length - 1] === 0) {
@@ -2201,24 +2208,10 @@
   };
 
   BN.prototype._ishlnsubmul = function _ishlnsubmul (num, mul, shift) {
-    // Bigger storage is needed
     var len = num.length + shift;
     var i;
-    if (this.words.length < len) {
-      var t = new Array(len);
-      for (i = 0; i < this.length; i++) {
-        t[i] = this.words[i];
-      }
-      this.words = t;
-    } else {
-      i = this.length;
-    }
 
-    // Zeroify rest
-    this.length = Math.max(this.length, len);
-    for (; i < this.length; i++) {
-      this.words[i] = 0;
-    }
+    this._expand(len);
 
     var w;
     var carry = 0;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -828,9 +828,7 @@
     var off = (bit / 26) | 0;
     var wbit = bit % 26;
 
-    while (this.length <= off) {
-      this.words[this.length++] = 0;
-    }
+    this._expand(off + 1);
 
     if (val) {
       this.words[off] = this.words[off] | (1 << wbit);

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -193,6 +193,8 @@ describe('BN.js/Binary', function () {
       assert.equal(new BN(0).setn(2, true).toString(2), '100');
       assert.equal(new BN(0).setn(27, true).toString(2),
         '1000000000000000000000000000');
+      assert.equal(new BN(0).setn(63, true).toString(16),
+        new BN(1).iushln(63).toString(16));
       assert.equal(new BN('1000000000000000000000000001', 2).setn(27, false)
         .toString(2), '1');
       assert.equal(new BN('101', 2).setn(2, false).toString(2), '1');

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -49,6 +49,8 @@ describe('BN.js/Binary', function () {
       assert.equal(new BN(2).bincn(1).bincn(1).toString(16),
         new BN(2).bincn(2).toString(16));
       assert.equal(new BN(0xffffff).bincn(1).toString(16), '1000001');
+      assert.equal(new BN(2).bincn(63).toString(16),
+        '8000000000000002');
     });
   });
 


### PR DESCRIPTION
Prepending the words[] array is used in `ishlnsubmul` (used by `divmod`), `inotn`, `setn` and `bincn`. They have various optimal/non-optimal versions.

Simplifies code a lot. It also seems to improve the speed of div and mod by a tiny fraction (on average it is within the error limit).

```
Old:
bn.js#div x 347,770 ops/sec ±1.70% (9 runs sampled)
bn.js#mod x 353,496 ops/sec ±0.77% (8 runs sampled)

New:
bn.js#div x 361,769 ops/sec ±1.12% (9 runs sampled)
bn.js#mod x 362,928 ops/sec ±1.48% (9 runs sampled)
```