### PR TITLE
Fix incorrect result from redPow with exponent = 0 and modulus = 1

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -3280,7 +3280,7 @@
   };
 
   Red.prototype.pow = function pow (a, num) {
-    if (num.isZero()) return new BN(1);
+    if (num.isZero()) return new BN(this.m.eqn(1) ? 0 : 1);
     if (num.cmpn(1) === 0) return a.clone();
 
     var windowSize = 4;

--- a/test/red-test.js
+++ b/test/red-test.js
@@ -113,11 +113,18 @@ describe('BN.js/Reduction context', function () {
           c.toString(16));
       });
 
-      it('should pow(base, 0) == 1', function () {
+      it('should pow(base, 0) == 1 when modulus > 1', function () {
         var base = new BN(256).toRed(BN.red('k256'));
         var exponent = new BN(0);
         var result = base.redPow(exponent);
         assert.equal(result.toString(), '1');
+      });
+
+      it('should pow(base, 0) == 0 when modulus == 1', function () {
+        var base = new BN(256).toRed(BN.red(new BN(1)));
+        var exponent = new BN(0);
+        var result = base.redPow(exponent);
+        assert.equal(result.toString(), '0');
       });
 
       it('should reduce when converting to red', function () {


### PR DESCRIPTION
In PR #44 fix for the issue with zero exponent missed the case when
modulus is 1: pow(x, y) % 1 will always produce 0, not 1.