### PR TITLE
Test fixes

### DIFF
--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -599,12 +599,12 @@ describe('BN.js/Arithmetic', function () {
     });
     it('should not allow 0 input', function () {
       assert.throws(function () {
-        BN(1).egcd(0);
+        new BN(1).egcd(0);
       });
     });
     it('should not allow negative input', function () {
       assert.throws(function () {
-        BN(1).egcd(-1);
+        new BN(1).egcd(-1);
       });
     });
   });

--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -81,7 +81,7 @@ describe('BN.js/Arithmetic', function () {
     it('should throw error with num eq 0x4000000', function () {
       assert.throws(function () {
         new BN(0).iaddn(0x4000000);
-      });
+      }, /^Error: Assertion failed$/);
     });
   });
 
@@ -164,7 +164,7 @@ describe('BN.js/Arithmetic', function () {
     it('should throw error with num eq 0x4000000', function () {
       assert.throws(function () {
         new BN(0).isubn(0x4000000);
-      });
+      }, /^Error: Assertion failed$/);
     });
   });
 
@@ -288,7 +288,7 @@ describe('BN.js/Arithmetic', function () {
     it('should throw error with num eq 0x4000000', function () {
       assert.throws(function () {
         new BN(0).imuln(0x4000000);
-      });
+      }, /^Error: Assertion failed$/);
     });
   });
 
@@ -600,12 +600,12 @@ describe('BN.js/Arithmetic', function () {
     it('should not allow 0 input', function () {
       assert.throws(function () {
         new BN(1).egcd(0);
-      });
+      }, /^Error: Assertion failed$/);
     });
     it('should not allow negative input', function () {
       assert.throws(function () {
         new BN(1).egcd(-1);
-      });
+      }, /^Error: Assertion failed$/);
     });
   });
 

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -27,8 +27,8 @@ describe('BN.js/Constructor', function () {
       var num = Math.pow(2, 53);
 
       assert.throws(function () {
-        num = new BN(num, 10);
-      });
+        return new BN(num, 10);
+      }, /^Error: Assertion failed$/);
     });
 
     it('should accept two-limb LE number', function () {

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -27,7 +27,7 @@ describe('BN.js/Constructor', function () {
       var num = Math.pow(2, 53);
 
       assert.throws(function () {
-        BN(num, 10);
+        num = new BN(num, 10);
       });
     });
 

--- a/test/red-test.js
+++ b/test/red-test.js
@@ -52,10 +52,10 @@ describe('BN.js/Reduction context', function () {
         var m = fn(p);
         var q = new BN(11).toRed(m);
 
-        var qr = q.redSqrt(true, p);
+        var qr = q.redSqrt();
         assert.equal(qr.redSqr().cmp(q), 0);
 
-        qr = q.redSqrt(false, p);
+        qr = q.redSqrt();
         assert.equal(qr.redSqr().cmp(q), 0);
 
         p = new BN(

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -137,7 +137,7 @@ describe('BN.js/Utils', function () {
       var n = new BN(0x123456);
       assert.throws(function () {
         n.toArray('be', 2);
-      });
+      }, /^Error: byte array longer than desired length$/);
     });
   });
 
@@ -167,7 +167,7 @@ describe('BN.js/Utils', function () {
       var n = new BN(1).iushln(54);
       assert.throws(function () {
         n.toNumber();
-      });
+      }, /^Error: Number can only safely store up to 53 bits$/);
     });
   });
 
@@ -202,7 +202,7 @@ describe('BN.js/Utils', function () {
       assert.equal(new BN(0x3fffffe).cmpn(0x3fffffd), 1);
       assert.throws(function () {
         new BN(0x3fffffe).cmpn(0x4000000);
-      });
+      }, /^Error: Number is too big$/);
       assert.equal(new BN(42).cmpn(-42), 1);
       assert.equal(new BN(-42).cmpn(42), -1);
       assert.equal(new BN(-42).cmpn(-42), 0);


### PR DESCRIPTION
* Fixed `assert.throw` tests, which were catching wrong exceptions.
* Removed extra arguments passed to `redSqrt`.