### PR TITLE
Don't accept invalid characters

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -235,6 +235,7 @@
 
   function parseBase (str, start, end, mul) {
     var r = 0;
+    var b = 0;
     var len = Math.min(str.length, end);
     for (var i = start; i < len; i++) {
       var c = str.charCodeAt(i) - 48;
@@ -243,16 +244,18 @@
 
       // 'a'
       if (c >= 49) {
-        r += c - 49 + 0xa;
+        b = c - 49 + 0xa;
 
       // 'A'
       } else if (c >= 17) {
-        r += c - 17 + 0xa;
+        b = c - 17 + 0xa;
 
       // '0' - '9'
       } else {
-        r += c;
+        b = c;
       }
+      assert(b < mul, 'Invalid character');
+      r += b;
     }
     return r;
   }

--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -90,6 +90,12 @@ describe('BN.js/Constructor', function () {
       assert.equal(new BN('1A6B765D8CDF', 16, 'le').toString(16),
         'df8c5d766b1a');
     });
+
+    it('should not accept wrong characters for base', function () {
+      assert.throws(function () {
+        return new BN('01FF');
+      }, /^Error: Invalid character$/);
+    });
   });
 
   describe('with Array input', function () {


### PR DESCRIPTION
Contructor from string accepted characters out of base range.
Fix by throwing exception when such character appears in the string.

_PS Spent the whole day trying to figure out why my code didn't work only to discover that I forgot to add 16 as base for constructor (similar to the test in this commit) :sweat_smile:_
