### PR TITLE
toJSON to default to interoperable hex (length % 2)

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -510,7 +510,7 @@
   };
 
   BN.prototype.toJSON = function toJSON () {
-    return this.toString(16);
+    return this.toString(16, 2);
   };
 
   BN.prototype.toBuffer = function toBuffer (endian, length) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -188,7 +188,11 @@ describe('BN.js/Utils', function () {
 
   describe('.toJSON', function () {
     it('should return hex string', function () {
-      assert.equal(new BN(0x123).toJSON(), '123');
+      assert.equal(new BN(0x123).toJSON(), '0123');
+    });
+    
+    it('should be padded to multiple of 2 bytes for interop', function () {
+      assert.equal(new BN(0x1).toJSON(), '01');
     });
   });
 


### PR DESCRIPTION
Thoughts?
This catches me out quite often and I always end up having to then roll in `.toString(16, 2)` rather than just letting `toJSON` work it.