### PR TITLE
bn: improve allocation speed for buffers. avoid deprecation warning.

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -530,7 +530,7 @@
 
     this.strip();
     var littleEndian = endian === 'le';
-    var res = new ArrayType(reqLength);
+    var res = allocate(ArrayType, reqLength);
 
     var b, i;
     var q = this.clone();
@@ -560,6 +560,13 @@
     }
 
     return res;
+  };
+
+  var allocate = function allocate (ArrayType, size) {
+    if (ArrayType.allocUnsafe) {
+      return ArrayType.allocUnsafe(size);
+    }
+    return new ArrayType(size);
   };
 
   if (Math.clz32) {


### PR DESCRIPTION
Node.js 8 calls out to `Buffer.alloc` when invoking `new Buffer()`. This ensures `Buffer.allocUnsafe` is called for some extra speed.