### PR TITLE
Properly exclude "buffer" from Webpack builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/indutny/bn.js/issues"
   },
   "homepage": "https://github.com/indutny/bn.js",
+  "browser": {
+    "buffer": false
+  },
   "devDependencies": {
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",


### PR DESCRIPTION
The technique of `require('buf' + 'fer')` doesn't actually fool Webpack.

The proper way to exclued a module is with the following `package.json` field:

https://github.com/defunctzombie/package-browser-field-spec