### PR TITLE
only define toBuffer if Buffer is defined

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -525,7 +525,7 @@
       return this.toArrayLike(Buffer, endian, length);
     };
   }
-  
+
   BN.prototype.toArray = function toArray (endian, length) {
     return this.toArrayLike(Array, endian, length);
   };

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -520,11 +520,12 @@
     return this.toString(16, 2);
   };
 
-  BN.prototype.toBuffer = function toBuffer (endian, length) {
-    assert(typeof Buffer !== 'undefined');
-    return this.toArrayLike(Buffer, endian, length);
-  };
-
+  if (Buffer) {
+    BN.prototype.toBuffer = function toBuffer (endian, length) {
+      return this.toArrayLike(Buffer, endian, length);
+    };
+  }
+  
   BN.prototype.toArray = function toArray (endian, length) {
     return this.toArrayLike(Array, endian, length);
   };


### PR DESCRIPTION
Alternative to having a run-time check?

Error is more legible too,  IMHO.

The existing error:
``` js
    if (!val) throw new Error(msg || 'Assertion failed');
              ^
Error: Assertion failed
```

The new 
``` js
TypeError: mynum.toBuffer is not a function
```