### PR TITLE
Trailing slash required for non-node buffer

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -53,6 +53,10 @@
     Buffer = require('buffer/').Buffer;
     // see https://github.com/feross/buffer for trailing slash explanation
   } catch (e) {
+    try {
+      Buffer = require('buffer').Buffer;
+    } catch (e) {
+    }
   }
 
   BN.isBN = function isBN (num) {

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -50,7 +50,8 @@
 
   var Buffer;
   try {
-    Buffer = require('buffer').Buffer;
+    Buffer = require('buffer/').Buffer;
+    // see https://github.com/feross/buffer for trailing slash explanation
   } catch (e) {
   }
 


### PR DESCRIPTION
This breaks on IOS and some browsers.