### PR TITLE
Add trailing slash to buffer import

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -327,7 +327,7 @@
     dest.red = this.red;
   };
 
-  BN.prototype.move = function move (dest) {
+  BN.prototype._move = function _move (dest) {
     dest.words = this.words;
     dest.length = this.length;
     dest.negative = this.negative;
@@ -3177,7 +3177,7 @@
   Red.prototype.imod = function imod (a) {
     if (this.prime) return this.prime.ireduce(a)._forceRed(this);
 
-    a.umod(this.m)._forceRed(this).move(a);
+    a.umod(this.m)._forceRed(this)._move(a);
     return a;
   };
 


### PR DESCRIPTION
Ensure that the module is used and not the native lib ... which are not identical and can break some string operations.