### PR TITLE
Padding fix

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -501,7 +501,7 @@
       if (this.isZero()) {
         out = '0' + out;
       }
-      while (out.length % padding !== 0) {
+      while (out.length < padding && out.length % padding !== 0) {
         out = '0' + out;
       }
       if (this.negative !== 0) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -47,6 +47,14 @@ describe('BN.js/Utils', function () {
         assert.equal(a.toString('hex', 64).length, 64);
       });
     });
+    describe('padding', function () {
+      it('should not apply if length is already larger', function () {
+        var number = '12345678';
+        var a = new BN(number);
+
+        assert.equal(a.toString(10, 6).length, number.length);
+      });
+    });
   });
 
   describe('.isNeg()', function () {


### PR DESCRIPTION
Fixes #198 
`toString` padding should only apply if length of number is smaller than requested padding.