### PR TITLE
new Buffer is deprecated and unsafe

### DIFF
--- a/test/constructor-test.js
+++ b/test/constructor-test.js
@@ -164,15 +164,15 @@ describe('BN.js/Constructor', function () {
   // the Array code is able to handle Buffer
   describe('with Buffer input', function () {
     it('should not fail on empty Buffer', function () {
-      assert.equal(new BN(new Buffer(0)).toString(16), '0');
+      assert.equal(new BN(Buffer.alloc(0)).toString(16), '0');
     });
 
     it('should import/export big endian', function () {
-      assert.equal(new BN(new Buffer('010203', 'hex')).toString(16), '10203');
+      assert.equal(new BN(Buffer.from('010203', 'hex')).toString(16), '10203');
     });
 
     it('should import little endian', function () {
-      assert.equal(new BN(new Buffer('010203', 'hex'), 'le').toString(16), '30201');
+      assert.equal(new BN(Buffer.from('010203', 'hex'), 'le').toString(16), '30201');
     });
   });
 

--- a/test/pummel/dh-group-test.js
+++ b/test/pummel/dh-group-test.js
@@ -16,7 +16,7 @@ describe('BN.js/Slow DH test', function () {
       var mont = BN.red(new BN(group.prime, 16));
       var priv = new BN(group.priv, 16);
       var multed = base.toRed(mont).redPow(priv).fromRed();
-      var actual = new Buffer(multed.toArray());
+      var actual = Buffer.from(multed.toArray());
       assert.equal(actual.toString('hex'), group.pub);
     });
   });

--- a/test/red-test.js
+++ b/test/red-test.js
@@ -222,7 +222,7 @@ describe('BN.js/Reduction context', function () {
       }
       return bits;
     }
-    var t = new Buffer('aff1651e4cd6036d57aa8b2a05ccf1a9d5a40166340ecbbdc55' +
+    var t = Buffer.from('aff1651e4cd6036d57aa8b2a05ccf1a9d5a40166340ecbbdc55' +
       'be10b568aa0aa3d05ce9a2fcec9df8ed018e29683c6051cb83e' +
       '46ce31ba4edb045356a8d0d80b', 'hex');
     var g = new BN('5c7ff6b06f8f143fe8288433493e4769c4d988ace5be25a0e24809670' +


### PR DESCRIPTION
#### What does it do?
`new Buffer` -> `Buffer.from` or `Buffer.alloc`.
We should not use Buffer constructor which is deprecated and unsafe.

#### Any helpful background information?
The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: 
* https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe

#### What else?
This PR failed CI test on Node.js `0.10`, `0.12`. However, those versions are no longer supported.
* https://github.com/nodejs/Release#end-of-life-releases