### PR TITLE
Improve error messages and argument checking in .imuln()

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -6,6 +6,14 @@
     if (!val) throw new Error(msg || 'Assertion failed');
   }
 
+  // compatibility replacement for Number.isInteger
+  // https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill
+  function isInteger (value) {
+    return typeof value === 'number' &&
+      isFinite(value) &&
+      Math.floor(value) === value;
+  }
+
   // Could use `inherits` module, but don't want to move from single file
   // architecture yet.
   function inherits (ctor, superCtor) {
@@ -1919,6 +1927,7 @@
     if (isNegNum) num = -num;
 
     assert(typeof num === 'number', 'Argument num must be a number');
+    assert(isInteger(num), 'Argument must be an integer');
     assert(num < 0x4000000, 'Argument not in supported range -0x4000000 < num < 0x4000000');
 
     // Carry

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -1918,7 +1918,7 @@
     var isNegNum = num < 0;
     if (isNegNum) num = -num;
 
-    assert(typeof num === 'number');
+    assert(typeof num === 'number', 'Argument num must be a number');
     assert(num < 0x4000000, 'Argument not in supported range -0x4000000 < num < 0x4000000');
 
     // Carry

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -1919,7 +1919,7 @@
     if (isNegNum) num = -num;
 
     assert(typeof num === 'number');
-    assert(num < 0x4000000);
+    assert(num < 0x4000000, 'Argument not in supported range -0x4000000 < num < 0x4000000');
 
     // Carry
     var carry = 0;

--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -288,7 +288,7 @@ describe('BN.js/Arithmetic', function () {
     it('should throw error with num eq 0x4000000', function () {
       assert.throws(function () {
         new BN(0).imuln(0x4000000);
-      }, /^Error: Assertion failed$/);
+      }, /^Error: Argument not in supported range -0x4000000 < num < 0x4000000$/);
     });
 
     it('should negate number if number is negative', function () {

--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -285,6 +285,16 @@ describe('BN.js/Arithmetic', function () {
       assert.equal(a.muln(0xdead).toString(16), c.toString(16));
     });
 
+    it('should throw error with num of type other than number', function () {
+      assert.throws(function () {
+        new BN(0).imuln('1');
+      }, /^Error: Argument num must be a number$/);
+
+      assert.throws(function () {
+        new BN(0).imuln(new BN(1));
+      }, /^Error: Argument num must be a number$/);
+    });
+
     it('should throw error with num eq 0x4000000', function () {
       assert.throws(function () {
         new BN(0).imuln(0x4000000);

--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -295,6 +295,28 @@ describe('BN.js/Arithmetic', function () {
       }, /^Error: Argument num must be a number$/);
     });
 
+    it('should throw error with num eq 1.5, -1.5 and NaN', function () {
+      assert.throws(function () {
+        new BN(0).imuln(1.5);
+      }, /^Error: Argument must be an integer$/);
+
+      assert.throws(function () {
+        new BN(0).imuln(-1.5);
+      }, /^Error: Argument must be an integer$/);
+
+      assert.throws(function () {
+        new BN(0).imuln(Infinity);
+      }, /^Error: Argument must be an integer$/);
+
+      assert.throws(function () {
+        new BN(0).imuln(-Infinity);
+      }, /^Error: Argument must be an integer$/);
+
+      assert.throws(function () {
+        new BN(0).imuln(NaN);
+      }, /^Error: Argument must be an integer$/);
+    });
+
     it('should throw error with num eq 0x4000000', function () {
       assert.throws(function () {
         new BN(0).imuln(0x4000000);


### PR DESCRIPTION
I got an "Assertion failed" after doing a `.muln(10**9)`, which was not very helpful. Thus this improved error messages and some more checks.