### PR TITLE
Add body {} to for loops / Silence the closure compiler warnings

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -2558,7 +2558,7 @@
     var xp = x.clone();
 
     while (!x.isZero()) {
-      for (var i = 0, im = 1; (x.words[0] & im) === 0 && i < 26; ++i, im <<= 1);
+      for (var i = 0, im = 1; (x.words[0] & im) === 0 && i < 26; ++i, im <<= 1) {};
       if (i > 0) {
         x.iushrn(i);
         while (i-- > 0) {
@@ -2572,7 +2572,7 @@
         }
       }
 
-      for (var j = 0, jm = 1; (y.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1);
+      for (var j = 0, jm = 1; (y.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1) {};
       if (j > 0) {
         y.iushrn(j);
         while (j-- > 0) {
@@ -2626,7 +2626,7 @@
     var delta = b.clone();
 
     while (a.cmpn(1) > 0 && b.cmpn(1) > 0) {
-      for (var i = 0, im = 1; (a.words[0] & im) === 0 && i < 26; ++i, im <<= 1);
+      for (var i = 0, im = 1; (a.words[0] & im) === 0 && i < 26; ++i, im <<= 1) {};
       if (i > 0) {
         a.iushrn(i);
         while (i-- > 0) {
@@ -2638,7 +2638,7 @@
         }
       }
 
-      for (var j = 0, jm = 1; (b.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1);
+      for (var j = 0, jm = 1; (b.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1) {};
       if (j > 0) {
         b.iushrn(j);
         while (j-- > 0) {


### PR DESCRIPTION

Closure compiler warns:
```
(somewhere) WARNING - If this if/for/while really shouldn't have a body, use {}
      for (var i = 0, im = 1; (x.words[0] & im) === 0 && i < 26; ++i, im <<= 1);
                                                                               ^

(somewhere) WARNING - If this if/for/while really shouldn't have a body, use {}
      for (var j = 0, jm = 1; (y.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1);
                                                                               ^

(somewhere) WARNING - If this if/for/while really shouldn't have a body, use {}
      for (var i = 0, im = 1; (a.words[0] & im) === 0 && i < 26; ++i, im <<= 1);
                                                                               ^

(somewhere) WARNING - If this if/for/while really shouldn't have a body, use {}
      for (var j = 0, jm = 1; (b.words[0] & jm) === 0 && j < 26; ++j, jm <<= 1);
                                                                               ^
```

It's consistent with the code style. Consider this:
```
   if (x.negative !== 0) {
      x = x.umod(p);
    } else {
      x = x.clone();
    }
```
If we wanted them to be consistent without this pull request, the one line ifs should've been:
```
   if (x.negative !== 0)
      x = x.umod(p);
    else
      x = x.clone();
  
```