### PR TITLE
Semver-major release: 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
-# v5.0.0
+5.0.0 / 2019-07-04
+------------------
 
-Major changes:
-
- - `.toJSON()` returns padded hex value
- - `new BN('string', base)` throws on invalid characters
- - Deprecate `.modn()`, please use `.modrn()` instead
- - Change `.strip()` to internal method
+- travis: update node versions (#205)
+- Refactor buffer constructor (#200)
+- lib: fix for negative numbers: imuln, modrn, idivn (#185)
+- bn: fix Red#imod (#178)
+- check unexpected high bits for invalid characters (#173)
+- document support very large integers (#158)
+- only define toBuffer if Buffer is defined (#172)
+- lib: better validation of string input (#151)
+- tests: reject decimal input in constructor (#91)
+- bn: make .strip() an internal method (#105)
+- lib: deprecate `.modn()` introduce `.modrn()`  (#112 #129 #130)
+- bn: don't accept invalid characters (#141)
+- package: use `files` insteadof `.npmignore`  (#152)
+- bn: improve allocation speed for buffers (#167)
+- toJSON to default to interoperable hex (length % 2) (#164)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bn.js",
-  "version": "4.11.8",
+  "version": "5.0.0",
   "description": "Big number implementation in pure javascript",
   "main": "lib/bn.js",
   "scripts": {


### PR DESCRIPTION
First, @indutny @calvinmetcalf thanks for trust and allowance to maintain this project. And sorry for delay.

Initially, I planned fill CHANGELOG.md and submit PR with minor version, but almost immediately I remembered that `master` branch already have semver-major changes which was never published. So I decide:

1) Summarize all current changes, submit PR with CHANGELOG for semver-major version: `5.0.0`
2) Merge/update/close current not semver-major PR's and release semver-minor version: `5.1.0` and so on..
3) Start work on unfinished semver-major changes from #129 for version: `6.0.0`

I'm not sure that I'll able finish `6.0.0`, but I'll try do this.

`5.0.0` can be considered as intermediate version. It's fastest way receive bn.js with patches from ~2 last years.

--

@indutny @calvinmetcalf I'd prefer not release version `5.0.0` without ACK. Are you ok with this plan?
No need merge this PR, this mostly preview. If you agree with proposed process, I'll commit changes directly to master.