### PR TITLE
Temporary disable jumboMulTo in BN#mulTo

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -1679,8 +1679,10 @@
   }
 
   function jumboMulTo (self, num, out) {
-    var fftm = new FFTM();
-    return fftm.mulp(self, num, out);
+    // Temporary disable, see https://github.com/indutny/bn.js/issues/211
+    // var fftm = new FFTM();
+    // return fftm.mulp(self, num, out);
+    return bigMulTo(self, num, out);
   }
 
   BN.prototype.mulTo = function mulTo (num, out) {


### PR DESCRIPTION
Currently there no solution for #211 
Result should be correct even if code is slow, `jumboMulTo` will be temporary disabled. It can be enabled back when code will be fixed.