### PR TITLE
Improve performance of toArrayLike

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -452,4 +452,10 @@ add('bitLength', {
   }
 });
 
+add('toArray', {
+  'bn.js': function () {
+    fixture.a1j.toArray();
+  }
+});
+
 start();

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -570,11 +570,17 @@
       var word = (this.words[i] << shift) | carry;
 
       res[position++] = word & 0xff;
-      res[position++] = (word >> 8) & 0xff;
-      res[position++] = (word >> 16) & 0xff;
+      if (position < res.length) {
+        res[position++] = (word >> 8) & 0xff;
+      }
+      if (position < res.length) {
+        res[position++] = (word >> 16) & 0xff;
+      }
 
       if (shift === 6) {
-        res[position++] = (word >> 24) & 0xff;
+        if (position < res.length) {
+          res[position++] = (word >> 24) & 0xff;
+        }
         carry = 0;
       } else {
         carry = word >>> 24;
@@ -599,11 +605,17 @@
       var word = (this.words[i] << shift) | carry;
 
       res[position--] = word & 0xff;
-      res[position--] = (word >> 8) & 0xff;
-      res[position--] = (word >> 16) & 0xff;
+      if (position >= 0) {
+        res[position--] = (word >> 8) & 0xff;
+      }
+      if (position >= 0) {
+        res[position--] = (word >> 16) & 0xff;
+      }
 
       if (shift === 6) {
-        res[position--] = (word >> 24) & 0xff;
+        if (position >= 0) {
+          res[position--] = (word >> 24) & 0xff;
+        }
         carry = 0;
       } else {
         carry = word >>> 24;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -565,8 +565,7 @@
     var position = 0;
     var carry = 0;
 
-    for (var i = 0; i < this.length; i++) {
-      var shift = (i % 4) * 2;
+    for (var i = 0, shift = 0; i < this.length; i++) {
       var word = (this.words[i] << shift) | carry;
 
       res[position++] = word & 0xff;
@@ -582,8 +581,10 @@
           res[position++] = (word >> 24) & 0xff;
         }
         carry = 0;
+        shift = 0;
       } else {
         carry = word >>> 24;
+        shift += 2;
       }
     }
 
@@ -600,8 +601,7 @@
     var position = res.length - 1;
     var carry = 0;
 
-    for (var i = 0; i < this.length; i++) {
-      var shift = (i % 4) * 2;
+    for (var i = 0, shift = 0; i < this.length; i++) {
       var word = (this.words[i] << shift) | carry;
 
       res[position--] = word & 0xff;
@@ -617,8 +617,10 @@
           res[position--] = (word >> 24) & 0xff;
         }
         carry = 0;
+        shift = 0;
       } else {
         carry = word >>> 24;
+        shift += 2;
       }
     }
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -541,39 +541,69 @@
   };
 
   BN.prototype.toArrayLike = function toArrayLike (ArrayType, endian, length) {
+    this._strip();
+
     var byteLength = this.byteLength();
     var reqLength = length || Math.max(1, byteLength);
     assert(byteLength <= reqLength, 'byte array longer than desired length');
     assert(reqLength > 0, 'Requested array length <= 0');
 
-    this._strip();
     var littleEndian = endian === 'le';
     var res = allocate(ArrayType, reqLength);
 
-    var b, i;
-    var q = this.clone();
-    if (!littleEndian) {
-      // Assume big-endian
-      for (i = 0; i < reqLength - byteLength; i++) {
-        res[i] = 0;
+    var i;
+    if (littleEndian) {
+      var position = 0;
+      var carry = 0;
+      for (i = 0; i < this.length; i++) {
+        var shift = (i % 4) * 2;
+        var word = (this.words[i] << shift) | carry;
+
+        res[position++] = word & 0xff;
+        res[position++] = (word >> 8) & 0xff;
+        res[position++] = (word >> 16) & 0xff;
+
+        if (shift === 6) {
+          res[position++] = (word >> 24) & 0xff;
+          carry = 0;
+        } else {
+          carry = word >>> 24;
+        }
       }
 
-      for (i = 0; !q.isZero(); i++) {
-        b = q.andln(0xff);
-        q.iushrn(8);
+      if (position < reqLength) {
+        res[position++] = carry;
 
-        res[reqLength - i - 1] = b;
+        while (position < reqLength) {
+          res[position++] = 0;
+        }
       }
     } else {
-      for (i = 0; !q.isZero(); i++) {
-        b = q.andln(0xff);
-        q.iushrn(8);
+      // big-endian
+      var position = reqLength - 1;
+      var carry = 0;
+      for (i = 0; i < this.length; i++) {
+        var shift = (i % 4) * 2;
+        var word = (this.words[i] << shift) | carry;
 
-        res[i] = b;
+        res[position--] = word & 0xff;
+        res[position--] = (word >> 8) & 0xff;
+        res[position--] = (word >> 16) & 0xff;
+
+        if (shift === 6) {
+          res[position--] = (word >> 24) & 0xff;
+          carry = 0;
+        } else {
+          carry = word >>> 24;
+        }
       }
 
-      for (; i < reqLength; i++) {
-        res[i] = 0;
+      if (position >= 0) {
+        res[position--] = carry;
+
+        while (position >= 0) {
+          res[position--] = 0;
+        }
       }
     }
 

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -540,6 +540,13 @@
     return this.toArrayLike(Array, endian, length);
   };
 
+  var allocate = function allocate (ArrayType, size) {
+    if (ArrayType.allocUnsafe) {
+      return ArrayType.allocUnsafe(size);
+    }
+    return new ArrayType(size);
+  };
+
   BN.prototype.toArrayLike = function toArrayLike (ArrayType, endian, length) {
     this._strip();
 
@@ -548,73 +555,68 @@
     assert(byteLength <= reqLength, 'byte array longer than desired length');
     assert(reqLength > 0, 'Requested array length <= 0');
 
-    var littleEndian = endian === 'le';
     var res = allocate(ArrayType, reqLength);
-
-    var i;
-    if (littleEndian) {
-      var position = 0;
-      var carry = 0;
-      for (i = 0; i < this.length; i++) {
-        var shift = (i % 4) * 2;
-        var word = (this.words[i] << shift) | carry;
-
-        res[position++] = word & 0xff;
-        res[position++] = (word >> 8) & 0xff;
-        res[position++] = (word >> 16) & 0xff;
-
-        if (shift === 6) {
-          res[position++] = (word >> 24) & 0xff;
-          carry = 0;
-        } else {
-          carry = word >>> 24;
-        }
-      }
-
-      if (position < reqLength) {
-        res[position++] = carry;
-
-        while (position < reqLength) {
-          res[position++] = 0;
-        }
-      }
-    } else {
-      // big-endian
-      var position = reqLength - 1;
-      var carry = 0;
-      for (i = 0; i < this.length; i++) {
-        var shift = (i % 4) * 2;
-        var word = (this.words[i] << shift) | carry;
-
-        res[position--] = word & 0xff;
-        res[position--] = (word >> 8) & 0xff;
-        res[position--] = (word >> 16) & 0xff;
-
-        if (shift === 6) {
-          res[position--] = (word >> 24) & 0xff;
-          carry = 0;
-        } else {
-          carry = word >>> 24;
-        }
-      }
-
-      if (position >= 0) {
-        res[position--] = carry;
-
-        while (position >= 0) {
-          res[position--] = 0;
-        }
-      }
-    }
-
+    var postfix = endian === 'le' ? 'LE' : 'BE';
+    this['_toArrayLike' + postfix](res, byteLength);
     return res;
   };
 
-  var allocate = function allocate (ArrayType, size) {
-    if (ArrayType.allocUnsafe) {
-      return ArrayType.allocUnsafe(size);
+  BN.prototype._toArrayLikeLE = function _toArrayLikeLE (res, byteLength) {
+    var position = 0;
+    var carry = 0;
+
+    for (var i = 0; i < this.length; i++) {
+      var shift = (i % 4) * 2;
+      var word = (this.words[i] << shift) | carry;
+
+      res[position++] = word & 0xff;
+      res[position++] = (word >> 8) & 0xff;
+      res[position++] = (word >> 16) & 0xff;
+
+      if (shift === 6) {
+        res[position++] = (word >> 24) & 0xff;
+        carry = 0;
+      } else {
+        carry = word >>> 24;
+      }
     }
-    return new ArrayType(size);
+
+    if (position < res.length) {
+      res[position++] = carry;
+
+      while (position < res.length) {
+        res[position++] = 0;
+      }
+    }
+  };
+
+  BN.prototype._toArrayLikeBE = function _toArrayLikeBE (res, byteLength) {
+    var position = res.length - 1;
+    var carry = 0;
+
+    for (var i = 0; i < this.length; i++) {
+      var shift = (i % 4) * 2;
+      var word = (this.words[i] << shift) | carry;
+
+      res[position--] = word & 0xff;
+      res[position--] = (word >> 8) & 0xff;
+      res[position--] = (word >> 16) & 0xff;
+
+      if (shift === 6) {
+        res[position--] = (word >> 24) & 0xff;
+        carry = 0;
+      } else {
+        carry = word >>> 24;
+      }
+    }
+
+    if (position >= 0) {
+      res[position--] = carry;
+
+      while (position >= 0) {
+        res[position--] = 0;
+      }
+    }
   };
 
   if (Math.clz32) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -144,8 +144,16 @@ describe('BN.js/Utils', function () {
   describe('.toBuffer', function () {
     it('should return proper Buffer', function () {
       var n = new BN(0x123456);
-      assert.deepEqual(n.toBuffer('be', 5).toString('hex'), '0000123456');
+      assert.equal(n.toBuffer('be', 5).toString('hex'), '0000123456');
       assert.deepEqual(n.toBuffer('le', 5).toString('hex'), '5634120000');
+
+      var s = '211e1566be78319bb949470577c2d4ac7e800a90d5104379478d8039451a8efe';
+      for (var i = 1; i <= s.length; i++) {
+        var slice = (i % 2 === 0 ? '' : '0') + s.slice(0, i);
+        var bn = new BN(slice, 16);
+        assert.equal(bn.toBuffer('be').toString('hex'), slice);
+        assert.equal(bn.toBuffer('le').toString('hex'), Buffer.from(slice, 'hex').reverse().toString('hex'));
+      }
     });
   });
 


### PR DESCRIPTION
From 6x to 174x improvement. Was need turn off bignum, because node 12 not supported.

```bash
$ # old 768 bytes number
$ SEED=27af4987aa60091dc42b1314d340e8c0 node index.js toArray
Seed: 27af4987aa60091dc42b1314d340e8c0
Benchmarking: toArray
bn.js#toArray x 3,437 ops/sec ±7.94% (7 runs sampled)
------------------------
Fastest is bn.js#toArray
========================
$ # old 32 bytes number
$ SEED=27af4987aa60091dc42b1314d340e8c0 node index.js toArray
Seed: 27af4987aa60091dc42b1314d340e8c0
Benchmarking: toArray
bn.js#toArray x 947,728 ops/sec ±3.40% (9 runs sampled)
------------------------
Fastest is bn.js#toArray
========================
$ # new 768 bytes number
$ SEED=27af4987aa60091dc42b1314d340e8c0 node index.js toArray
Seed: 27af4987aa60091dc42b1314d340e8c0
Benchmarking: toArray
bn.js#toArray x 600,559 ops/sec ±3.99% (8 runs sampled)
------------------------
Fastest is bn.js#toArray
========================
$ # new 32 bytes number
$ SEED=27af4987aa60091dc42b1314d340e8c0 node index.js toArray
Seed: 27af4987aa60091dc42b1314d340e8c0
Benchmarking: toArray
bn.js#toArray x 6,293,522 ops/sec ±1.83% (8 runs sampled)
------------------------
Fastest is bn.js#toArray
========================
```