### PR TITLE
Benchmark for BigInt

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,4 +1,5 @@
-/* eslint-disable new-cap, no-new */
+/* global BigInt */
+/* eslint-disable new-cap, no-new, no-unused-expressions */
 
 var benchmark = require('benchmark');
 var crypto = require('crypto');
@@ -36,6 +37,10 @@ function add (op, obj) {
       console.log('Benchmarking: ' + op);
 
       Object.keys(obj).forEach(function (name) {
+        if (name === 'BigInt' && typeof BigInt === 'undefined') {
+          return;
+        }
+
         if (name === 'bignum' && bignum === undefined) {
           return;
         }
@@ -113,6 +118,13 @@ while (fixtures.length < 25) {
   fixture.am1 = fixture.a1.toRed(bn.red('k256'));
   fixture.pow1 = fixture.am1.fromRed();
 
+  // BigInt
+  fixture.a2 = BigInt(fixture.a1.toString(10));
+  fixture.b2 = BigInt(fixture.b1.toString(10));
+  fixture.a2j = BigInt(fixture.a1j.toString(10));
+  fixture.b2j = BigInt(fixture.b1j.toString(10));
+  fixture.as2 = fixture.a2 * fixture.a2 + 0x2adbeefn;
+
   // bignum
   if (bignum) {
     fixture.a3 = new bignum(a, 16);
@@ -158,6 +170,9 @@ add('create-10', {
   'bn.js': function (fixture) {
     new bn(fixture.a10base, 10);
   },
+  BigInt: function (fixture) {
+    BigInt(fixture.a10base);
+  },
   bignum: function (fixture) {
     new bignum(fixture.a10base, 10);
   },
@@ -197,6 +212,9 @@ add('toString-10', {
   'bn.js': function (fixture) {
     fixture.a1.toString(10);
   },
+  BigInt: function (fixture) {
+    fixture.a2.toString(10);
+  },
   bignum: function (fixture) {
     fixture.a3.toString(10);
   },
@@ -214,6 +232,9 @@ add('toString-10', {
 add('toString-hex', {
   'bn.js': function (fixture) {
     fixture.a1.toString(16);
+  },
+  BigInt: function (fixture) {
+    fixture.a2.toString(16);
   },
   bignum: function (fixture) {
     fixture.a3.toString(16);
@@ -236,6 +257,9 @@ add('add', {
   'bn.js': function (fixture) {
     fixture.a1.add(fixture.b1);
   },
+  BigInt: function (fixture) {
+    fixture.a2 + fixture.b2;
+  },
   bignum: function (fixture) {
     fixture.a3.add(fixture.b3);
   },
@@ -256,6 +280,9 @@ add('add', {
 add('sub', {
   'bn.js': function (fixture) {
     fixture.b1.sub(fixture.a1);
+  },
+  BigInt: function (fixture) {
+    fixture.a2 - fixture.b2;
   },
   bignum: function (fixture) {
     fixture.b3.sub(fixture.a3);
@@ -281,6 +308,9 @@ add('mul', {
   'bn.js[FFT]': function (fixture) {
     fixture.a1.mulf(fixture.b1);
   },
+  BigInt: function (fixture) {
+    fixture.a2 * fixture.b2;
+  },
   bignum: function (fixture) {
     fixture.a3.mul(fixture.b3);
   },
@@ -305,6 +335,9 @@ add('mul-jumbo', {
   'bn.js[FFT]': function (fixture) {
     fixture.a1j.mulf(fixture.b1j);
   },
+  BigInt: function (fixture) {
+    fixture.a2j * fixture.b2j;
+  },
   bignum: function (fixture) {
     fixture.a3j.mul(fixture.b3j);
   },
@@ -325,6 +358,9 @@ add('mul-jumbo', {
 add('sqr', {
   'bn.js': function (fixture) {
     fixture.a1.mul(fixture.a1);
+  },
+  BigInt: function (fixture) {
+    fixture.a2 * fixture.a2;
   },
   bignum: function (fixture) {
     fixture.a3.mul(fixture.a3);
@@ -347,6 +383,9 @@ add('div', {
   'bn.js': function (fixture) {
     fixture.as1.div(fixture.a1);
   },
+  BigInt: function (fixture) {
+    fixture.as2 / fixture.a2;
+  },
   bignum: function (fixture) {
     fixture.as3.div(fixture.a3);
   },
@@ -364,6 +403,9 @@ add('div', {
 add('mod', {
   'bn.js': function (fixture) {
     fixture.as1.mod(fixture.a1);
+  },
+  BigInt: function (fixture) {
+    fixture.as2 / fixture.a2;
   },
   bignum: function (fixture) {
     fixture.as3.mod(fixture.a3);

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -101,11 +101,17 @@ while (fixtures.length < 25) {
   var aj = prng.randomBytes(768).toString('hex');
   var bj = prng.randomBytes(768).toString('hex');
 
+  fixture.a10base = new bn(a, 16).toString(10);
+  fixture.a16base = new bn(a, 16).toString(16);
+
   // BN
   fixture.a1 = new bn(a, 16);
   fixture.b1 = new bn(b, 16);
   fixture.a1j = new bn(aj, 16);
   fixture.b1j = new bn(bj, 16);
+  fixture.as1 = fixture.a1.mul(fixture.a1).iaddn(0x2adbeef);
+  fixture.am1 = fixture.a1.toRed(bn.red('k256'));
+  fixture.pow1 = fixture.am1.fromRed();
 
   // bignum
   if (bignum) {
@@ -113,6 +119,7 @@ while (fixtures.length < 25) {
     fixture.b2 = new bignum(b, 16);
     fixture.a2j = new bignum(aj, 16);
     fixture.b2j = new bignum(bj, 16);
+    fixture.as2 = fixture.a2.mul(fixture.a2).add(0x2adbeef);
   }
 
   // bigi
@@ -120,45 +127,31 @@ while (fixtures.length < 25) {
   fixture.b4 = new bigi(b, 16);
   fixture.a4j = new bigi(aj, 16);
   fixture.b4j = new bigi(bj, 16);
+  fixture.as4 = fixture.a4.multiply(fixture.a4).add(bigi.valueOf(0x2adbeef));
 
   // sjcl
   fixture.a5 = new sjcl(a, 16);
   fixture.b5 = new sjcl(b, 16);
   fixture.a5j = new sjcl(aj, 16);
   fixture.b5j = new sjcl(bj, 16);
+  // fixture.as5 = fixture.a5.mul(fixture.a5).add(0x2adbeef);
+  fixture.am5 = new sjcl.prime.p256k(fixture.a5);
 
   // BigInteger
   fixture.a6 = new BigInteger(a, 16);
   fixture.b6 = new BigInteger(b, 16);
   fixture.a6j = new BigInteger(aj, 16);
   fixture.b6j = new BigInteger(bj, 16);
+  fixture.as6 = fixture.a6.multiply(fixture.a6).add(
+    new BigInteger('2adbeef', 16));
 
   // SilentMattBigInteger
   fixture.a7 = SilentMattBigInteger.parse(a, 16);
   fixture.b7 = SilentMattBigInteger.parse(b, 16);
-
   fixture.a7j = SilentMattBigInteger.parse(aj, 16);
   fixture.b7j = SilentMattBigInteger.parse(aj, 16);
-
-  //
-  fixture.as1 = fixture.a1.mul(fixture.a1).iaddn(0x2adbeef);
-  if (bignum) {
-    fixture.as2 = fixture.a2.mul(fixture.a2).add(0x2adbeef);
-  }
-  fixture.as4 = fixture.a4.multiply(fixture.a4).add(bigi.valueOf(0x2adbeef));
-  // fixture.as5 = fixture.a5.mul(fixture.a5).add(0x2adbeef);
-  fixture.as6 = fixture.a6.multiply(fixture.a6).add(
-    new BigInteger('2adbeef', 16));
   fixture.as7 = fixture.a7.multiply(fixture.a7).add(
     SilentMattBigInteger.parse('2adbeef', 16));
-
-  fixture.am1 = fixture.a1.toRed(bn.red('k256'));
-  fixture.am5 = new sjcl.prime.p256k(fixture.a5);
-
-  fixture.pow1 = fixture.am1.fromRed();
-
-  fixture.a10base = fixture.a1.toString(10);
-  fixture.a16base = a;
 }
 
 add('create-10', {

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -115,11 +115,11 @@ while (fixtures.length < 25) {
 
   // bignum
   if (bignum) {
-    fixture.a2 = new bignum(a, 16);
-    fixture.b2 = new bignum(b, 16);
-    fixture.a2j = new bignum(aj, 16);
-    fixture.b2j = new bignum(bj, 16);
-    fixture.as2 = fixture.a2.mul(fixture.a2).add(0x2adbeef);
+    fixture.a3 = new bignum(a, 16);
+    fixture.b3 = new bignum(b, 16);
+    fixture.a3j = new bignum(aj, 16);
+    fixture.b3j = new bignum(bj, 16);
+    fixture.as3 = fixture.a3.mul(fixture.a3).add(0x2adbeef);
   }
 
   // bigi
@@ -198,7 +198,7 @@ add('toString-10', {
     fixture.a1.toString(10);
   },
   bignum: function (fixture) {
-    fixture.a2.toString(10);
+    fixture.a3.toString(10);
   },
   bigi: function (fixture) {
     fixture.a4.toString(10);
@@ -216,7 +216,7 @@ add('toString-hex', {
     fixture.a1.toString(16);
   },
   bignum: function (fixture) {
-    fixture.a2.toString(16);
+    fixture.a3.toString(16);
   },
   bigi: function (fixture) {
     fixture.a4.toString(16);
@@ -237,7 +237,7 @@ add('add', {
     fixture.a1.add(fixture.b1);
   },
   bignum: function (fixture) {
-    fixture.a2.add(fixture.b2);
+    fixture.a3.add(fixture.b3);
   },
   bigi: function (fixture) {
     fixture.a4.add(fixture.b4);
@@ -258,7 +258,7 @@ add('sub', {
     fixture.b1.sub(fixture.a1);
   },
   bignum: function (fixture) {
-    fixture.b2.sub(fixture.a2);
+    fixture.b3.sub(fixture.a3);
   },
   bigi: function (fixture) {
     fixture.b4.subtract(fixture.a4);
@@ -282,7 +282,7 @@ add('mul', {
     fixture.a1.mulf(fixture.b1);
   },
   bignum: function (fixture) {
-    fixture.a2.mul(fixture.b2);
+    fixture.a3.mul(fixture.b3);
   },
   bigi: function (fixture) {
     fixture.a4.multiply(fixture.b4);
@@ -306,7 +306,7 @@ add('mul-jumbo', {
     fixture.a1j.mulf(fixture.b1j);
   },
   bignum: function (fixture) {
-    fixture.a2j.mul(fixture.b2j);
+    fixture.a3j.mul(fixture.b3j);
   },
   bigi: function (fixture) {
     fixture.a4j.multiply(fixture.b4j);
@@ -327,7 +327,7 @@ add('sqr', {
     fixture.a1.mul(fixture.a1);
   },
   bignum: function (fixture) {
-    fixture.a2.mul(fixture.a2);
+    fixture.a3.mul(fixture.a3);
   },
   bigi: function (fixture) {
     fixture.a4.square();
@@ -348,7 +348,7 @@ add('div', {
     fixture.as1.div(fixture.a1);
   },
   bignum: function (fixture) {
-    fixture.as2.div(fixture.a2);
+    fixture.as3.div(fixture.a3);
   },
   bigi: function (fixture) {
     fixture.as4.divide(fixture.a4);
@@ -366,7 +366,7 @@ add('mod', {
     fixture.as1.mod(fixture.a1);
   },
   bignum: function (fixture) {
-    fixture.as2.mod(fixture.a2);
+    fixture.as3.mod(fixture.a3);
   },
   bigi: function (fixture) {
     fixture.as4.mod(fixture.a4);
@@ -411,7 +411,7 @@ add('pow k256', {
     fixture.am1.redPow(fixture.pow1);
   },
   bignum: function (fixture) {
-    fixture.a2.powm(fixture.a2, prime1);
+    fixture.a3.powm(fixture.a3, prime1);
   }
 });
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -134,11 +134,11 @@ while (fixtures.length < 25) {
   fixture.b6j = new BigInteger(bj, 16);
 
   // SilentMattBigInteger
-  fixture.a8 = SilentMattBigInteger.parse(a, 16);
-  fixture.b8 = SilentMattBigInteger.parse(b, 16);
+  fixture.a7 = SilentMattBigInteger.parse(a, 16);
+  fixture.b7 = SilentMattBigInteger.parse(b, 16);
 
-  fixture.a8j = SilentMattBigInteger.parse(aj, 16);
-  fixture.b8j = SilentMattBigInteger.parse(aj, 16);
+  fixture.a7j = SilentMattBigInteger.parse(aj, 16);
+  fixture.b7j = SilentMattBigInteger.parse(aj, 16);
 
   //
   fixture.as1 = fixture.a1.mul(fixture.a1).iaddn(0x2adbeef);
@@ -149,7 +149,7 @@ while (fixtures.length < 25) {
   // fixture.as5 = fixture.a5.mul(fixture.a5).add(0x2adbeef);
   fixture.as6 = fixture.a6.multiply(fixture.a6).add(
     new BigInteger('2adbeef', 16));
-  fixture.as8 = fixture.a8.multiply(fixture.a8).add(
+  fixture.as7 = fixture.a7.multiply(fixture.a7).add(
     SilentMattBigInteger.parse('2adbeef', 16));
 
   fixture.am1 = fixture.a1.toRed(bn.red('k256'));
@@ -214,7 +214,7 @@ add('toString-10', {
     fixture.a6.toString(10);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.a8.toString(10);
+    fixture.a7.toString(10);
   }
 });
 
@@ -235,7 +235,7 @@ add('toString-hex', {
     fixture.a6.toString(16);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.a8.toString(16);
+    fixture.a7.toString(16);
   }
 });
 
@@ -256,7 +256,7 @@ add('add', {
     fixture.a6.add(fixture.b6);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.a8.add(fixture.a8);
+    fixture.a7.add(fixture.a7);
   }
 });
 
@@ -277,7 +277,7 @@ add('sub', {
     fixture.b6.subtract(fixture.a6);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.b8.subtract(fixture.a8);
+    fixture.b7.subtract(fixture.a7);
   }
 });
 
@@ -301,7 +301,7 @@ add('mul', {
     fixture.a6.multiply(fixture.b6);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.a8.multiply(fixture.b8);
+    fixture.a7.multiply(fixture.b7);
   }
 });
 
@@ -325,7 +325,7 @@ add('mul-jumbo', {
     fixture.a6j.multiply(fixture.b6j);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.a8j.multiply(fixture.b8j);
+    fixture.a7j.multiply(fixture.b7j);
   }
 });
 
@@ -346,7 +346,7 @@ add('sqr', {
     fixture.a6.multiply(fixture.a6);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.a8.multiply(fixture.a8);
+    fixture.a7.multiply(fixture.a7);
   }
 });
 
@@ -364,7 +364,7 @@ add('div', {
     fixture.as6.divide(fixture.a6);
   },
   'silentmatt-biginteger': function (fixture) {
-    fixture.as8.divide(fixture.a8);
+    fixture.as7.divide(fixture.a7);
   }
 });
 
@@ -385,9 +385,9 @@ add('mod', {
       : remainder;
   },
   'silentmatt-biginteger': function (fixture) {
-    var remainder = fixture.as8.remainder(fixture.a8);
+    var remainder = fixture.as7.remainder(fixture.a7);
     return remainder.compare(BigInteger.ZERO) < 0
-      ? remainder.add(fixture.a8)
+      ? remainder.add(fixture.a7)
       : remainder;
   }
 });

--- a/package.json
+++ b/package.json
@@ -32,8 +32,12 @@
     "buffer": false
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.2",
     "mocha": "^6.1.4",
     "standardx": "^4.0.0"
+  },
+  "standardx": {
+    "parser": "babel-eslint"
   },
   "eslintConfig": {
     "rules": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,46 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
   integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
   dependencies:
     "@babel/highlight" "^7.0.0"
+
+"@babel/generator@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.5.5.tgz#873a7f936a3c89491b43536d12245b626664e3cf"
+  integrity sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==
+  dependencies:
+    "@babel/types" "^7.5.5"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
 
 "@babel/highlight@^7.0.0":
   version "7.5.0"
@@ -17,6 +51,44 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.4.4", "@babel/parser@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
+  integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
+
+"@babel/template@^7.1.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
+"@babel/traverse@^7.0.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
+  integrity sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.5.5"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.5.5"
+    "@babel/types" "^7.5.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/types@^7.0.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
+  integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
 
 acorn-jsx@^5.0.0:
   version "5.0.1"
@@ -89,6 +161,18 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+
+babel-eslint@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.2.tgz#182d5ac204579ff0881684b040560fdcc1558456"
+  integrity sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -210,7 +294,7 @@ debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
+debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -406,6 +490,14 @@ eslint-plugin-standard@~4.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz#f845b45109c99cd90e77796940a344546c8f6b5c"
   integrity sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==
 
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
@@ -503,9 +595,9 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
 esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 execa@^1.0.0:
   version "1.0.0"
@@ -671,15 +763,15 @@ glob@^7.0.5, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.7.0:
+globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
-  integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
+  integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
 
 growl@1.10.5:
   version "1.10.5"
@@ -709,9 +801,11 @@ he@1.2.0:
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hosted-git-info@^2.1.4:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
-  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.2.tgz#a35c3f355ac1249f1093c0c2a542ace8818c171a"
+  integrity sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==
+  dependencies:
+    lru-cache "^5.1.1"
 
 iconv-lite@^0.4.24:
   version "0.4.24"
@@ -871,6 +965,11 @@ js-yaml@3.13.1, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -956,7 +1055,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -974,6 +1073,13 @@ loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -1394,9 +1500,9 @@ punycode@^2.1.0:
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 react-is@^16.8.1:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -1441,9 +1547,9 @@ resolve-from@^4.0.0:
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.5.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -1526,6 +1632,11 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+source-map@^0.5.0:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -1683,9 +1794,9 @@ supports-color@^5.3.0:
     has-flag "^3.0.0"
 
 table@^5.2.3:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.4.tgz#6e0f88fdae3692793d1077fd172a4667afe986a6"
-  integrity sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.5.tgz#c8f4ea2d8fee08c0027fac27b0ec0a4fe01dfa42"
+  integrity sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==
   dependencies:
     ajv "^6.10.2"
     lodash "^4.17.14"
@@ -1708,6 +1819,16 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 tslib@^1.9.0:
   version "1.10.0"
@@ -1739,9 +1860,9 @@ uri-js@^4.2.2:
     punycode "^2.1.0"
 
 v8-compile-cache@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
-  integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
@@ -1804,6 +1925,11 @@ xtend@^4.0.1:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yargs-parser@13.0.0:
   version "13.0.0"


### PR DESCRIPTION
@mathiasbynens can you share benchmark which was used in article? https://v8.dev/features/bigint#use-cases

`bn.js` VS `BigInt`

```bash
$ node --version
v12.8.0
$ uname -r
5.1.20-300.fc30.x86_64
$ grep 'model name' -m 1 /proc/cpuinfo
model name	: Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
```

```bash
$ SEED=d3010f0048b13a628169fc81a4c0318d node index.js 
Load bignum error: Cannot find module 'bignum'
Seed: d3010f0048b13a628169fc81a4c0318d
Benchmarking: create-10
bn.js#create-10 x 962,231 ops/sec ±1.13% (9 runs sampled)
BigInt#create-10 x 2,684,467 ops/sec ±0.72% (9 runs sampled)
------------------------
Fastest is BigInt#create-10
========================
Benchmarking: toString-10
bn.js#toString-10 x 466,028 ops/sec ±0.94% (9 runs sampled)
BigInt#toString-10 x 691,462 ops/sec ±0.41% (7 runs sampled)
------------------------
Fastest is BigInt#toString-10
========================
Benchmarking: toString-hex
bn.js#toString-hex x 274,852 ops/sec ±1.54% (8 runs sampled)
BigInt#toString-hex x 7,493,824 ops/sec ±1.60% (9 runs sampled)
------------------------
Fastest is BigInt#toString-hex
========================
Benchmarking: add
bn.js#add x 10,930,340 ops/sec ±0.88% (9 runs sampled)
BigInt#add x 10,876,360 ops/sec ±0.59% (9 runs sampled)
------------------------
Fastest is bn.js#add,BigInt#add
========================
Benchmarking: sub
bn.js#sub x 8,617,757 ops/sec ±1.47% (8 runs sampled)
BigInt#sub x 10,467,586 ops/sec ±0.76% (9 runs sampled)
------------------------
Fastest is BigInt#sub
========================
Benchmarking: mul
bn.js#mul x 3,649,547 ops/sec ±0.80% (8 runs sampled)
BigInt#mul x 5,113,954 ops/sec ±8.59% (8 runs sampled)
------------------------
Fastest is BigInt#mul
========================
Benchmarking: mul-jumbo
bn.js#mul-jumbo x 3,735 ops/sec ±0.59% (9 runs sampled)
BigInt#mul-jumbo x 22,364 ops/sec ±3.43% (8 runs sampled)
------------------------
Fastest is BigInt#mul-jumbo
========================
Benchmarking: sqr
bn.js#sqr x 3,667,287 ops/sec ±0.25% (8 runs sampled)
BigInt#sqr x 5,581,414 ops/sec ±1.21% (9 runs sampled)
------------------------
Fastest is BigInt#sqr
========================
Benchmarking: div
bn.js#div x 615,096 ops/sec ±0.69% (8 runs sampled)
BigInt#div x 2,321,200 ops/sec ±0.62% (9 runs sampled)
------------------------
Fastest is BigInt#div
========================
Benchmarking: mod
bn.js#mod x 625,200 ops/sec ±1.59% (9 runs sampled)
BigInt#mod x 2,279,238 ops/sec ±1.47% (9 runs sampled)
------------------------
Fastest is BigInt#mod
========================
```