### PR TITLE
Release: 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+5.1.1 / 2019-12-24
+------------------
+
+- Temporary workaround for BN#_move (#236)
+- Add eslintrc instead config in package.json (#237)
+
 5.1.0 / 2019-12-23
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bn.js",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Big number implementation in pure javascript",
   "main": "lib/bn.js",
   "scripts": {


### PR DESCRIPTION
- Temporary workaround for BN#_move (#236)
- Add eslintrc instead config in package.json (#237)