### PR TITLE
Add support for defined but not implemented Symbol.for

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -371,9 +371,9 @@
   // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#Browser_compatibility
   if (typeof Symbol !== 'undefined' && typeof Symbol.for === 'function') {
     try {
-        BN.prototype[Symbol.for('nodejs.util.inspect.custom')] = inspect;
+      BN.prototype[Symbol.for('nodejs.util.inspect.custom')] = inspect;
     } catch(e) {
-        BN.prototype.inspect = inspect;
+      BN.prototype.inspect = inspect;
     }
   } else {
     BN.prototype.inspect = inspect;

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -370,7 +370,11 @@
   // Check Symbol.for because not everywhere where Symbol defined
   // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#Browser_compatibility
   if (typeof Symbol !== 'undefined' && typeof Symbol.for === 'function') {
-    BN.prototype[Symbol.for('nodejs.util.inspect.custom')] = inspect;
+    try {
+        BN.prototype[Symbol.for('nodejs.util.inspect.custom')] = inspect;
+    } catch(e) {
+        BN.prototype.inspect = inspect;
+    }
   } else {
     BN.prototype.inspect = inspect;
   }

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -372,7 +372,7 @@
   if (typeof Symbol !== 'undefined' && typeof Symbol.for === 'function') {
     try {
       BN.prototype[Symbol.for('nodejs.util.inspect.custom')] = inspect;
-    } catch(e) {
+    } catch (e) {
       BN.prototype.inspect = inspect;
     }
   } else {


### PR DESCRIPTION
`Symbol.for` is defined but not implemented in NGINX njs plugin and throws exception.

> err InternalError: not implemented
>     at Symbol.for (native)
> 

http://hg.nginx.org/njs/file/default/src/njs_symbol.c#l174

Suggestion for https://github.com/indutny/bn.js/blob/5707aed66c02ae10f8c7d59f5244fcce1c24cdb6/lib/bn.js#L373

Wrap in try/catch block and revert to `BN.prototype.inspect = inspect;` on error.