### PR TITLE
fix: Buffer not using global in browser, closes #259

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -50,7 +50,11 @@
 
   var Buffer;
   try {
-    Buffer = require('buffer').Buffer;
+    if (typeof window !== 'undefined' && typeof window.Buffer !== 'undefined') {
+      Buffer = window.Buffer;
+    } else {
+      Buffer = require('buffer').Buffer;
+    }
   } catch (e) {
   }
 


### PR DESCRIPTION
Closes issue #259

Redeclaring Buffer prohibits using a globally-defined polyfill.