### PR TITLE
Remove node matrix from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,22 +9,11 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node:
-          - 8
-          - 10
-          - 12
     steps:
       - name: Fetch code
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
 
       - name: Restore node_modules cache
         uses: actions/cache@v1


### PR DESCRIPTION
Some deps require a higher node version that we test in CI: https://github.com/indutny/bn.js/runs/1962262706