### PR TITLE
New release: 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+5.2.0 / 2021-02-23
+------------------
+
+- fix: Buffer not using global in browser (#260)
+- Fix LE constructor for HEX (#265)
+
 5.1.3 / 2020-08-14
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bn.js",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "description": "Big number implementation in pure javascript",
   "keywords": [
     "BN",


### PR DESCRIPTION
- fix: Buffer not using global in browser (#260)
- Fix LE constructor for HEX (#265)