### PR TITLE
Fix serious issue in `.toString(16)`

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -480,15 +480,15 @@
         var w = this.words[i];
         var word = (((w << off) | carry) & 0xffffff).toString(16);
         carry = (w >>> (24 - off)) & 0xffffff;
-        if (carry !== 0 || i !== this.length - 1) {
-          out = zeros[6 - word.length] + word + out;
-        } else {
-          out = word + out;
-        }
         off += 2;
         if (off >= 26) {
           off -= 26;
           i--;
+        }
+        if (carry !== 0 || i !== this.length - 1) {
+          out = zeros[6 - word.length] + word + out;
+        } else {
+          out = word + out;
         }
       }
       if (carry !== 0) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -5,6 +5,16 @@ var BN = require('../').BN;
 
 describe('BN.js/Utils', function () {
   describe('.toString()', function () {
+    describe('hex no padding', function () {
+      it('should have same length as input', function () {
+        var hex = '1';
+        for (var i = 1; i <= 128; i++) {
+          var n = new BN(hex, 16);
+          assert.equal(n.toString(16).length, i);
+          hex = hex + '0';
+        }
+      });
+    });
     describe('binary padding', function () {
       it('should have a length of 256', function () {
         var a = new BN(0);


### PR DESCRIPTION
In some circumstances the hex encoding of big numbers is wrong. In addition to a display issue, given that the the hex string if often used as an intermediate representation in transport/conversion scenarios, the re-constructed big number can actually change its value, creating serious issues.