### PR TITLE
Document the max plain JS number argument value

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ is the list of them in the order of appearance in the function name:
 ### Postfixes
 
 * `n` - the argument of the function must be a plain JavaScript
-  Number. Decimals are not supported.
+  Number. Decimals are not supported. The number passed must be smaller than 0x4000000 (67_108_864). Otherwise, an error is thrown.
 * `rn` - both argument and return value of the function are plain JavaScript
   Numbers. Decimals are not supported.
 


### PR DESCRIPTION
As mentioned here https://github.com/indutny/bn.js/issues/306 max plain JS number argument value seems to undocumented. I've added info in README.md.