### PR TITLE
backport(4.x): Fix serious issue in `.toString(16)` (#295)

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -452,15 +452,15 @@
         var w = this.words[i];
         var word = (((w << off) | carry) & 0xffffff).toString(16);
         carry = (w >>> (24 - off)) & 0xffffff;
-        if (carry !== 0 || i !== this.length - 1) {
-          out = zeros[6 - word.length] + word + out;
-        } else {
-          out = word + out;
-        }
         off += 2;
         if (off >= 26) {
           off -= 26;
           i--;
+        }
+        if (carry !== 0 || i !== this.length - 1) {
+          out = zeros[6 - word.length] + word + out;
+        } else {
+          out = word + out;
         }
       }
       if (carry !== 0) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -5,6 +5,16 @@ var BN = require('../').BN;
 
 describe('BN.js/Utils', function () {
   describe('.toString()', function () {
+    describe('hex no padding', function () {
+      it('should have same length as input', function () {
+        var hex = '1';
+        for (var i = 1; i <= 128; i++) {
+          var n = new BN(hex, 16);
+          assert.equal(n.toString(16).length, i);
+          hex = hex + '0';
+        }
+      });
+    });
     describe('binary padding', function () {
       it('should have a length of 256', function () {
         var a = new BN(0);


### PR DESCRIPTION
This backports #295 to `v4.x` branch

4.x usage is still at ~75%
E.g. `elliptic` uses 4.x

![telegram-cloud-photo-size-2-5292272682706003588-y](https://github.com/user-attachments/assets/0abb759b-e535-47d8-9029-215884a8dce4)


Original description:
```
* Add test for `.toString(16)`

* Fix serious issue in `.toString(16)`

The hex encoding of some numbers is wrong. Since the string representation is also used for interoperability between BigInt libraries, this bug is causing a number modification when a BN.js number is converted into another BigInt class, for example the BigNumber of ethers.js.
```