### PR TITLE
imuln/muln incorrectly handle multiplication by zero

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -2008,6 +2008,7 @@
       this.words[i] = carry;
       this.length++;
     }
+    this.length = num === 0 ? 1 : this.length;
 
     return isNegNum ? this.ineg() : this;
   };


### PR DESCRIPTION
Hello,

I have encountered an issue with the `imuln` function.
Multiplying a BN by zero using `imuln/muln(0)` does not reduce the length.

Steps to reproduce:

```js
> var zero = new BN(0);
> new BN(1111111111).muln(0).eq(zero)
false
```