### PR TITLE
fix: internal name of P25519

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -3197,7 +3197,7 @@
     // 2 ^ 255 - 19
     MPrime.call(
       this,
-      '25519',
+      'p25519',
       '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed');
   }
   inherits(P25519, MPrime);


### PR DESCRIPTION
Change to consistently name `p25519` like the other primes. 

It's a cosmetic change since this.name is not used, currently. It will prevent issues in case it's used in the future.