### PR TITLE
fix: clear surplus words in notn so result stays below 2 ** width

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -910,6 +910,12 @@
     // Handle the residue
     if (bitsLeft > 0) {
       this.words[i] = ~this.words[i] & (0x3ffffff >> (26 - bitsLeft));
+      i++;
+    }
+
+    // Clear words above the requested width so the result stays below 2 ** width
+    for (; i < this.length; i++) {
+      this.words[i] = 0;
     }
 
     // And remove leading zeroes

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -231,5 +231,23 @@ describe('BN.js/Binary', function () {
         '11111111111111111111111111111111' +
         '111111111111111111111111111111000111');
     });
+
+    it('should mask result to width when value is wider than width', function () {
+      // width < bitLength(value): the result must stay below 2 ** width,
+      // so the high words above the requested width have to be cleared.
+      var cases = [
+        ['5991996425021', 15],
+        ['4503599627370497', 26],
+        ['18446744073709551615', 4],
+        ['123456789012345678901234567890', 33]
+      ];
+
+      cases.forEach(function (pair) {
+        var value = pair[0];
+        var width = pair[1];
+        var expected = (~BigInt(value) & ((1n << BigInt(width)) - 1n)).toString();
+        assert.equal(new BN(value).notn(width).toString(), expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
When `width` is smaller than the bit length of the value, `notn(width)` returns a number larger than `2 ** width`.

## Repro

```js
new BN("5991996425021").notn(15).toString()
// actual   "5991949171906"
// expected "31938"

new BN("4503599627370497").notn(26).toString()
// actual   "4503599694479358"
// expected "67108862"
```

Checked against the native BigInt oracle for the same operation:

```js
(~BigInt("5991996425021") & ((1n << 15n) - 1n)).toString() // "31938"
```

## Contract

`notn(width)` is the w-bit bitwise complement: the result must be `< 2 ** width`. Single-word values are fine; the bug only shows when the value occupies more 26-bit words than `width` requires.

## Root cause

`inotn` computes `bytesNeeded = Math.ceil(width / 26)`, inverts the words covering `[0, bytesNeeded)` plus the residue word, but never clears the words above that range. `_expand` only grows `this.length`, it never shrinks, so when the value already has more words than the width needs, those surplus high words are left untouched and survive `_strip()`.

Existing `.notn()` tests only use `width >= bitLength(value)`, so `width < bitLength` was never exercised.

## Fix

Zero `this.words[j]` for every `j` from the first index past the requested width up to `this.length`, before stripping.

## Tests

Added a case to `test/binary-test.js` `.notn()` that checks multi-word values with `width < bitLength` against the BigInt oracle. It fails on master and passes with the fix. Full suite stays green (175 passing, lint clean).