### PR TITLE
fix: normalize sign when imuln multiplies by zero

### DIFF
--- a/lib/bn.js
+++ b/lib/bn.js
@@ -2014,7 +2014,10 @@
       this.words[i] = carry;
       this.length++;
     }
-    this.length = num === 0 ? 1 : this.length;
+    if (num === 0) {
+      this.length = 1;
+      this.negative = 0;
+    }
 
     return isNegNum ? this.ineg() : this;
   };

--- a/lib/bn.js
+++ b/lib/bn.js
@@ -2016,7 +2016,7 @@
     }
     if (num === 0) {
       this.length = 1;
-      this.negative = 0;
+      this._normSign();
     }
 
     return isNegNum ? this.ineg() : this;

--- a/test/arithmetic-test.js
+++ b/test/arithmetic-test.js
@@ -315,6 +315,15 @@ describe('BN.js/Arithmetic', function () {
       assert.equal(b.clone().imuln(0).isZero(), true);
       assert.equal(b.clone().muln(0).isZero(), true);
     });
+
+    it('should not keep the sign when multiplying a negative by zero', function () {
+      var a = new BN(-42);
+      assert.equal(a.clone().imuln(0).negative, 0);
+      assert.equal(a.clone().imuln(0).toString(), '0');
+      assert.equal(a.clone().muln(0).toString(), '0');
+      assert.equal(a.clone().muln(0).isNeg(), false);
+      assert.equal(a.clone().muln(0).eq(new BN(0)), true);
+    });
   });
 
   describe('.pow()', function () {


### PR DESCRIPTION
Multiplying a negative number by the plain number 0 zeroed the words but left the negative flag set, producing a negative zero. That value reported `isNeg()` as true, was not `eq()` to zero, compared as less than zero, and printed as `-0`. `new BN(-5).mul(new BN(0))` correctly gives `0`; only the `imuln`/`muln` path diverged.

This clears the sign along with the length when the factor is zero so the result is a plain zero. The existing zero-multiplication test only checked `isZero()`, which is true even for a negative zero, so the added test asserts the sign directly.
